### PR TITLE
Fixes sourcetype to properly parse json data

### DIFF
--- a/flare_splunk_integration/default/inputs.conf
+++ b/flare_splunk_integration/default/inputs.conf
@@ -1,7 +1,6 @@
 [script://$SPLUNK_HOME/etc/apps/flare_splunk_integration/bin/input.py]
 interval = * * * * *
 python.version = python3
-source = $SPLUNK_HOME/var/log/syslog
-sourcetype = flare-events
-index = flare
+source = Flare
+sourcetype = json_no_timestamp
 passAuth = admin


### PR DESCRIPTION
- Removes `index=flare` from `inputs.conf` so now all data will be sent to the "main" index.
- Changes `source` to "Flare" so that events are easily searched for using `index="main" source="Flare"`
- Fixes sourcetype as it should be a "pretrained" Splunk type. Changed to `json_no_timestamp` and this now parses the json correctly and is now readable. 
<img width="1511" alt="Screenshot 2024-10-28 at 1 13 01 PM" src="https://github.com/user-attachments/assets/9b67d0ba-e82b-411a-b2d4-0682a51f43d2">
