### PR TITLE
Event ingestion flow

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,40 @@
+extend-select = [
+    "I",
+    "C411",
+    "C413",
+    "C414",
+    "C416",
+    "C417",
+    "C419",
+    "RUF015",
+    "E401",
+]
+extend-safe-fixes = [
+    "C411",
+    "C413",
+    "C414",
+    "C416",
+    "C417",
+    "C419",
+    "RUF015",
+    "E401",
+]
+ignore = [
+    "E722",
+    "F403",
+    "F405",
+]
+
+[isort]
+force-single-line = true
+no-sections = true
+lines-after-imports = 2
+lines-between-types = 1
+force-wrap-aliases = true
+combine-as-imports = true
+
+[format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ lint: setup-web venv-tools mypy format-check
 
 .PHONY: mypy
 mypy: venv-tools
-	venv-tools/bin/mypy packages/flare
+	venv-tools/bin/mypy --config-file mypy.ini packages/flare
 
 .PHONY: splunk-local
 splunk-local: venv setup-web

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,17 @@
 [mypy]
+namespace_packages = True
+explicit_package_bases = True
+ignore_missing_imports = True
+warn_unused_ignores = True
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_no_return = True
+no_implicit_optional = True
+check_untyped_defs = True
+strict_equality = True
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+disallow_untyped_calls = True
 exclude = (vendor*|flare/flare*)/$
 follow_imports = skip
 mypy_path = packages/flare/python/vendor

--- a/packages/configuration-screen/src/models/splunk.ts
+++ b/packages/configuration-screen/src/models/splunk.ts
@@ -9,7 +9,6 @@ export interface SplunkApplicationNamespace {
 export interface SplunkPassword {
     name: string;
     _properties: {
-        // eslint-disable-next-line camelcase
         clear_password: string;
     };
 }

--- a/packages/flare/python/flare_external_requests.py
+++ b/packages/flare/python/flare_external_requests.py
@@ -1,8 +1,10 @@
-import sys
-import os
-import splunk  # type: ignore[import-not-found]
 import json
+import os
+import splunk
+import sys
+
 from typing import Any
+
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "vendor"))
 from flareio import FlareApiClient
@@ -17,7 +19,7 @@ def parseParams(payload: str) -> dict[str, Any]:
 
 
 class FlareUserTenants(splunk.rest.BaseRestHandler):
-    def handle_POST(self):
+    def handle_POST(self) -> None:
         payload = self.request["payload"]
         params = parseParams(payload)
         self.flare_client = FlareApiClient(api_key=params["apiKey"])

--- a/requirements.tools.txt
+++ b/requirements.tools.txt
@@ -2,3 +2,4 @@ pytest==8.3.2
 mypy==1.12.1
 ruff==0.7.0
 splunk-appinspect==3.8.0
+isort==5.13.2


### PR DESCRIPTION
- The cronjob runs every minute, but the script will early exit if it's been less than 10 minutes since the last event fetch
- The start date for the 'time' parameter is reset to today whenever the tenant is changed
- The 'next' value is saved per tenant to avoid duplicate events when switching between tenants
- Retrieving 50 events per request to reduce the amount of requests done on the Flare backend