### PR TITLE
Refactored some of the python architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@
 
 At the time of this writing, Splunk Enterprise is at version 9.3.0. This version of splunk requires Python v3.9.
 
-
 ## Installation
 
-For now, see [(this confluence page)](https://flareio.atlassian.net/wiki/spaces/engineering/pages/384401447/Splunk+Enterprise) for instructions on how to install and configure this Splunk integration with your Splunk Enterprise instance.
+To be updated once documentation is publicly available
 
 ## Architecture Overview
 

--- a/packages/flare/bin/constants.py
+++ b/packages/flare/bin/constants.py
@@ -18,5 +18,8 @@ class PasswordKeys(Enum):
 class CollectionKeys(Enum):
     CURRENT_TENANT_ID = "current_tenant_id"
     START_DATE = "start_date"
-    NEXT_TOKEN = "next_"
     TIMESTAMP_LAST_FETCH = "timestamp_last_fetch"
+
+    @staticmethod
+    def get_next_token(tenantId: int) -> str:
+        return f"next_{tenantId}"

--- a/packages/flare/bin/flare_external_requests.py
+++ b/packages/flare/bin/flare_external_requests.py
@@ -3,31 +3,23 @@ import os
 import splunk
 import sys
 
-from typing import Any
+from urllib import parse
 
 
 sys.path.insert(0, os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "vendor"))
-from flareio import FlareApiClient
+from flare import FlareAPI
 from logger import Logger
-
-
-def parseParams(payload: str) -> dict[str, Any]:
-    params = {}
-    for param_entry in payload.split("&"):
-        param = param_entry.split("=", 1)
-        params[param[0]] = param[1]
-    return params
 
 
 class FlareUserTenants(splunk.rest.BaseRestHandler):
     def handle_POST(self) -> None:
         logger = Logger(class_name=__file__)
         payload = self.request["payload"]
-        params = parseParams(payload)
-        self.flare_client = FlareApiClient(api_key=params["apiKey"])
-        user_tenants_response = self.flare_client.get("firework/v2/me/tenants")
-        self.response.setHeader("Content-Type", "application/json")
+        params = parse.parse_qs(payload)
+        flare_api = FlareAPI(api_key=params["apiKey"][0])
+        user_tenants_response = flare_api.retrieve_tenants()
         tenants_response = user_tenants_response.json()
         logger.debug(tenants_response)
+        self.response.setHeader("Content-Type", "application/json")
         self.response.write(json.dumps(tenants_response))

--- a/packages/flare/bin/logger.py
+++ b/packages/flare/bin/logger.py
@@ -9,15 +9,15 @@ from typing import Any
 
 class Logger:
     def __init__(self, *, class_name: str) -> None:
-        SPLUNK_HOME = os.environ.get("SPLUNK_HOME")
+        splunk_home = os.environ.get("SPLUNK_HOME")
         is_local_build = False
         log_filepath = ""
-        if SPLUNK_HOME:
+        if splunk_home:
             log_filepath = os.path.join(
-                SPLUNK_HOME, "var", "log", "splunk", f"{APP_NAME}.log"
+                splunk_home, "var", "log", "splunk", f"{APP_NAME}.log"
             )
-            APPLICATION_FOLDER = os.path.join(SPLUNK_HOME, "etc", "apps", APP_NAME)
-            is_local_build = os.path.islink(APPLICATION_FOLDER)
+            application_folder = os.path.join(splunk_home, "etc", "apps", APP_NAME)
+            is_local_build = os.path.islink(application_folder)
         else:
             log_filepath = os.path.join(tempfile.gettempdir(), f"{APP_NAME}.log")
 
@@ -26,7 +26,7 @@ class Logger:
 
         if is_local_build:
             # If the application is a symlink, it's been installed locally
-            self._logger.setLevel(logging.DEBUG)
+            self._logger.setLevel(logging.INFO)
         else:
             self._logger.setLevel(logging.ERROR)
         formatter = logging.Formatter("%(asctime)s %(levelname)-5s %(message)s")

--- a/packages/flare/src/main/resources/splunk/default/app.conf
+++ b/packages/flare/src/main/resources/splunk/default/app.conf
@@ -24,5 +24,4 @@ description = The Flare app allows you to integrate your Flare alerts with the S
 version = 0.1.0
 
 [triggers]
-reload.flare = simple
 reload.splunk_create = simple

--- a/packages/flare/src/main/resources/splunk/default/flare.conf
+++ b/packages/flare/src/main/resources/splunk/default/flare.conf
@@ -1,2 +1,0 @@
-[endpoints]
-me_feed_endpoint = /firework/v2/me/feed


### PR DESCRIPTION
- Removed endpoint config (flare)
- Using urllib to parse query parameters (flare_external_requests)
- Renamed local variables to removed all caps (flare_external_requests)
- Since endpoint config is removed, the tenants requests is done inside flare.py
- Created static method to generate get_next_token() collection key (constants)
- Moved the handling of the event_feed in the main method of the cron job (cron_job_ingest_events)
- Calling save_last_fetched before the first fetch to avoid race conditions (cron_job_ingest_events)
- Always pass the filter params in the fetching of the feed to make sure that the 'next' token is valid (flare)
- Removed our status code check and handling the exception from raise_for_status (cron_job_ingest_events)