### PR TITLE
Return a better error message when api key is empty

### DIFF
--- a/packages/flare/bin/flare_external_requests.py
+++ b/packages/flare/bin/flare_external_requests.py
@@ -17,9 +17,13 @@ class FlareUserTenants(splunk.rest.BaseRestHandler):
         logger = Logger(class_name=__file__)
         payload = self.request["payload"]
         params = parse.parse_qs(payload)
-        flare_api = FlareAPI(api_key=params["apiKey"][0])
-        user_tenants_response = flare_api.retrieve_tenants()
-        tenants_response = user_tenants_response.json()
-        logger.debug(tenants_response)
-        self.response.setHeader("Content-Type", "application/json")
-        self.response.write(json.dumps(tenants_response))
+
+        if "apiKey" in params:
+            flare_api = FlareAPI(api_key=params["apiKey"][0])
+            user_tenants_response = flare_api.retrieve_tenants()
+            tenants_response = user_tenants_response.json()
+            logger.debug(tenants_response)
+            self.response.setHeader("Content-Type", "application/json")
+            self.response.write(json.dumps(tenants_response))
+        else:
+            raise Exception("API Key is required")


### PR DESCRIPTION
<img width="414" alt="image" src="https://github.com/user-attachments/assets/7d0828fe-82f0-4181-8894-adb5c2dae5bb">
