### PR TITLE
Adds build attribute under install stanza

### DIFF
--- a/packages/flare/src/main/resources/splunk/default/app.conf
+++ b/packages/flare/src/main/resources/splunk/default/app.conf
@@ -12,6 +12,7 @@ id = flare
 [install]
 state_change_requires_restart = true
 is_configured = 0
+build = 2
 
 [ui]
 is_visible = 1


### PR DESCRIPTION
This is required in order for an app update via Marketplace to bust the static files cache and display the updated UI.