### PR TITLE
Severity filter

### DIFF
--- a/packages/flare/bin/constants.py
+++ b/packages/flare/bin/constants.py
@@ -14,6 +14,7 @@ class PasswordKeys(Enum):
     API_KEY = "api_key"
     TENANT_ID = "tenant_id"
     INGEST_METADATA_ONLY = "ingest_metadata_only"
+    SEVERITIES_FILTER = "severities_filter"
 
 
 class CollectionKeys(Enum):

--- a/packages/flare/bin/cron_job_ingest_events.py
+++ b/packages/flare/bin/cron_job_ingest_events.py
@@ -93,6 +93,7 @@ def main(
     api_key = get_api_key(storage_passwords=storage_passwords)
     tenant_id = get_tenant_id(storage_passwords=storage_passwords)
     ingest_metadata_only = get_ingest_metadata_only(storage_passwords=storage_passwords)
+    severities_filter = get_severities_filter(storage_passwords=storage_passwords)
 
     save_last_fetched(kvstore=kvstore)
     save_last_ingested_tenant_id(kvstore=kvstore, tenant_id=tenant_id)
@@ -103,6 +104,7 @@ def main(
         api_key=api_key,
         tenant_id=tenant_id,
         ingest_metadata_only=ingest_metadata_only,
+        severities=severities_filter,
     ):
         save_last_fetched(kvstore=kvstore)
 
@@ -156,6 +158,18 @@ def get_ingest_metadata_only(storage_passwords: StoragePasswords) -> bool:
         )
         == "true"
     )
+
+
+def get_severities_filter(storage_passwords: StoragePasswords) -> list[str]:
+    severities_filter = get_storage_password_value(
+        storage_passwords=storage_passwords,
+        password_key=PasswordKeys.SEVERITIES_FILTER.value,
+    )
+
+    if severities_filter:
+        return severities_filter.split(",")
+
+    return []
 
 
 def get_next(kvstore: KVStoreCollections, tenant_id: int) -> Optional[str]:
@@ -281,6 +295,7 @@ def fetch_feed(
     api_key: str,
     tenant_id: int,
     ingest_metadata_only: bool,
+    severities: list[str],
 ) -> Iterator[tuple[dict, str]]:
     try:
         flare_api = FlareAPI(api_key=api_key, tenant_id=tenant_id)
@@ -292,6 +307,7 @@ def fetch_feed(
             next=next,
             start_date=start_date,
             ingest_metadata_only=ingest_metadata_only,
+            severities=severities,
         ):
             yield event_next
     except Exception as e:

--- a/packages/flare/bin/flare_external_requests.py
+++ b/packages/flare/bin/flare_external_requests.py
@@ -41,3 +41,20 @@ class FlareUserTenants(splunk.rest.BaseRestHandler):
         logger.debug(f"FlareUserTenants: {response_json}")
         self.response.setHeader("Content-Type", "application/json")
         self.response.write(json.dumps(response_json))
+
+
+class FlareSeverityFilters(splunk.rest.BaseRestHandler):
+    def handle_POST(self) -> None:
+        logger = Logger(class_name=__file__)
+        payload = self.request["payload"]
+        params = parse.parse_qs(payload)
+
+        if "apiKey" not in params:
+            raise Exception("API Key is required")
+
+        flare_api = FlareAPI(api_key=params["apiKey"][0])
+        response = flare_api.fetch_filters_severity()
+        response_json = response.json()
+        logger.debug(f"FlareSeverityFilters: {response_json}")
+        self.response.setHeader("Content-Type", "application/json")
+        self.response.write(json.dumps(response_json))

--- a/packages/flare/src/main/resources/splunk/default/restmap.conf
+++ b/packages/flare/src/main/resources/splunk/default/restmap.conf
@@ -7,3 +7,8 @@ python.version = python3
 match=/fetch_user_tenants
 handler=flare_external_requests.FlareUserTenants
 python.version = python3
+
+[script:flare_external_requests_severity_filters]
+match=/fetch_severity_filters
+handler=flare_external_requests.FlareSeverityFilters
+python.version = python3

--- a/packages/flare/src/main/resources/splunk/default/web.conf
+++ b/packages/flare/src/main/resources/splunk/default/web.conf
@@ -5,3 +5,7 @@ methods=POST
 [expose:flare_external_requests_user_tenants]
 pattern=fetch_user_tenants
 methods=POST
+
+[expose:flare_external_requests_severity_filters]
+pattern=fetch_severity_filters
+methods=POST

--- a/packages/flare/tests/bin/test_flare_wrapper.py
+++ b/packages/flare/tests/bin/test_flare_wrapper.py
@@ -44,6 +44,7 @@ def test_flare_full_data_without_metadata(
         next=None,
         start_date=None,
         ingest_metadata_only=True,
+        severities=[],
     ):
         assert next_token == expected_return_value["next"]
         events.append(event)
@@ -105,6 +106,7 @@ def test_flare_full_data_with_metadata(
         next=None,
         start_date=None,
         ingest_metadata_only=False,
+        severities=[],
     ):
         assert next_token == expected_return_value["next"]
         events.append(event)
@@ -147,6 +149,7 @@ def test_flare_full_data_with_metadata_and_exception(
                 next=None,
                 start_date=None,
                 ingest_metadata_only=False,
+                severities=[],
             )
         )
 

--- a/packages/flare/tests/bin/test_ingest_events.py
+++ b/packages/flare/tests/bin/test_ingest_events.py
@@ -228,6 +228,7 @@ def test_fetch_feed_expect_exception() -> None:
         api_key="some_key",
         tenant_id=11111,
         ingest_metadata_only=False,
+        severities=[],
     ):
         pass
 
@@ -262,6 +263,7 @@ def test_fetch_feed_expect_feed_response(
         api_key="some_key",
         tenant_id=11111,
         ingest_metadata_only=False,
+        severities=[],
     ):
         assert next_token == next
         events.append(event)
@@ -320,4 +322,5 @@ def test_main_expect_normal_run(
         api_key="some_api_key",
         tenant_id=111,
         ingest_metadata_only=False,
+        severities=[],
     )

--- a/packages/react-components/src/components/SeverityOption.css
+++ b/packages/react-components/src/components/SeverityOption.css
@@ -1,0 +1,28 @@
+.toggle {
+    position: relative;
+    width: 1rem;
+    height: 1rem;
+    display: inline-block;
+    z-index: 2;
+}
+
+.toggle input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.dot {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 1rem;
+    width: 1rem;
+    border-radius: 50%;
+    border-width: 1px;
+    border-style: solid;
+    display: inline-block;
+}

--- a/packages/react-components/src/components/SeverityOption.tsx
+++ b/packages/react-components/src/components/SeverityOption.tsx
@@ -1,0 +1,47 @@
+import React, { FC, useState } from 'react';
+
+import { Severity } from '../models/flare';
+import './SeverityOption.css';
+import './Tooltip.css';
+
+const SeverityOption: FC<{
+    isChecked?: boolean;
+    severity: Severity;
+    onCheckChange: (isChecked: boolean) => void;
+}> = ({ isChecked = false, severity, onCheckChange }) => {
+    const [isShowingTooltip, setShowingTooltip] = useState(false);
+
+    return (
+        <div className="tooltip-container">
+            <label
+                className="toggle"
+                onMouseEnter={(): void => setShowingTooltip(true)}
+                onMouseLeave={(): void => setShowingTooltip(false)}
+            >
+                <input
+                    type="checkbox"
+                    checked={isChecked}
+                    onChange={(e): void => onCheckChange(e.target.checked)}
+                />
+                <span
+                    className="dot"
+                    style={{
+                        borderColor: severity.color,
+                        backgroundColor: isChecked ? severity.color : '',
+                    }}
+                />
+            </label>
+            <div
+                hidden={!isShowingTooltip}
+                className="tooltip"
+                style={{
+                    zIndex: 1,
+                }}
+            >
+                {severity.label}
+            </div>
+        </div>
+    );
+};
+
+export default SeverityOption;

--- a/packages/react-components/src/components/SeverityOptions.css
+++ b/packages/react-components/src/components/SeverityOptions.css
@@ -1,0 +1,6 @@
+#severities-container {
+    display: flex;
+    flex-direction: row;
+    margin-top: 0.5rem;
+    gap: 0.75rem;
+}

--- a/packages/react-components/src/components/SeverityOptions.tsx
+++ b/packages/react-components/src/components/SeverityOptions.tsx
@@ -1,0 +1,50 @@
+import React, { FC } from 'react';
+
+import { Severity } from '../models/flare';
+import SeverityOption from './SeverityOption';
+import './SeverityOptions.css';
+
+const SeverityOptions: FC<{
+    severities: Severity[];
+    selectedSeverities: Severity[];
+    setSelectedSeverities: (selectedSeverities: Severity[]) => void;
+}> = ({ severities, selectedSeverities, setSelectedSeverities }) => {
+    const isSeverityChecked = (severity: Severity): boolean => {
+        return (
+            selectedSeverities.findIndex(
+                (selectedSeverity) => selectedSeverity.value === severity.value
+            ) >= 0
+        );
+    };
+
+    const handleOnSeverityChange = (severity: Severity, isChecked: boolean): void => {
+        if (isChecked) {
+            setSelectedSeverities([...selectedSeverities, severity]);
+        } else {
+            setSelectedSeverities(
+                selectedSeverities.filter(
+                    (selectedSeverity) => selectedSeverity.value !== severity.value
+                )
+            );
+        }
+    };
+
+    return (
+        <div id="severities-container">
+            {severities.map((severity) => {
+                return (
+                    <SeverityOption
+                        key={severities.indexOf(severity)}
+                        isChecked={isSeverityChecked(severity)}
+                        severity={severity}
+                        onCheckChange={(isChecked): void =>
+                            handleOnSeverityChange(severity, isChecked)
+                        }
+                    />
+                );
+            })}
+        </div>
+    );
+};
+
+export default SeverityOptions;

--- a/packages/react-components/src/models/constants.ts
+++ b/packages/react-components/src/models/constants.ts
@@ -16,6 +16,7 @@ export enum PasswordKeys {
     API_KEY = 'api_key',
     TENANT_ID = 'tenant_id',
     INGEST_METADATA_ONLY = 'ingest_metadata_only',
+    SEVERITIES_FILTER = 'severities_filter',
 }
 
 export enum CollectionKeys {

--- a/packages/react-components/src/models/flare.ts
+++ b/packages/react-components/src/models/flare.ts
@@ -8,3 +8,9 @@ export enum ConfigurationStep {
     UserPreferences = 2,
     Completed = 3,
 }
+
+export interface Severity {
+    value: string;
+    label: string;
+    color: string;
+}

--- a/packages/react-components/src/tests/flare.fixture.tsx
+++ b/packages/react-components/src/tests/flare.fixture.tsx
@@ -1,0 +1,31 @@
+import { Severity } from '../models/flare';
+
+export function getAllSeverities(): Severity[] {
+    return [
+        {
+            value: 'info',
+            label: 'Info',
+            color: '#A7C4FF',
+        },
+        {
+            value: 'low',
+            label: 'Low',
+            color: '#FFE030',
+        },
+        {
+            value: 'medium',
+            label: 'Medium',
+            color: '#F8C100',
+        },
+        {
+            value: 'high',
+            label: 'High',
+            color: '#FF842A',
+        },
+        {
+            value: 'critical',
+            label: 'Critical',
+            color: '#FF0C47',
+        },
+    ];
+}

--- a/packages/react-components/src/tests/setupConfiguration.unit.tsx
+++ b/packages/react-components/src/tests/setupConfiguration.unit.tsx
@@ -1,5 +1,45 @@
-import { getRedirectUrl } from '../utils/setupConfiguration';
+import {
+    convertSeverityFilterToArray,
+    getRedirectUrl,
+    getSeverityFilterValue,
+} from '../utils/setupConfiguration';
+import { getAllSeverities } from './flare.fixture';
 
 test('Flare Redirect URL', () => {
     expect(getRedirectUrl()).toBe('/app/flare');
+});
+
+/** Severity filters */
+test('Select one severity', () => {
+    const allSeverities = getAllSeverities();
+    const selectedSeverities = [allSeverities[0]];
+    const severityFilter = getSeverityFilterValue(selectedSeverities, allSeverities);
+    expect(severityFilter).toBe(allSeverities[0].value);
+});
+
+test('Select no severity', () => {
+    const allSeverities = getAllSeverities();
+    const selectedSeverities = [];
+    expect(() => getSeverityFilterValue(selectedSeverities, allSeverities)).toThrow(Error);
+});
+
+test('Select all severities', () => {
+    const allSeverities = getAllSeverities();
+    const selectedSeverities = [...allSeverities];
+    const severityFilter = getSeverityFilterValue(selectedSeverities, allSeverities);
+    expect(severityFilter).toBe('');
+});
+
+test('Convert severity filter (all severities)', () => {
+    const allSeverities = getAllSeverities();
+    const severityFilter = [];
+    const severities = convertSeverityFilterToArray(severityFilter, allSeverities);
+    expect(severities).toStrictEqual(allSeverities);
+});
+
+test('Convert severity filter (part of them)', () => {
+    const allSeverities = getAllSeverities();
+    const severityFilter = [allSeverities[0].value];
+    const severities = convertSeverityFilterToArray(severityFilter, allSeverities);
+    expect(severities).toStrictEqual([allSeverities[0]]);
 });


### PR DESCRIPTION
- Fetch available severities via the rest API
    - Added picker in the user preference configuration step
    - Unit tests
    - Logic filtering is:
            - Minimum one severity must be selected
            - If all of the severities are selected, no filter is applied in case we add new severities in the future
            - Otherwise, pass the severities selected as a filter when fetching the events

https://github.com/user-attachments/assets/a3509f03-b58a-41b4-ba47-824b918b8ced

