### PR TITLE
Force Python 3.9 since that's what we need for our scripts to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ package: packages/flare/bin/vendor
 
 .PHONY: publish
 publish: output/flare.tar.gz
-	curl -u "$(SPLUNKBASE_CREDS)" --request POST https://splunkbase.splunk.com/api/v1/app/7602/new_release/ -F "files[]=@./output/flare.tar.gz" -F "filename=flare.tar.gz" -F "splunk_versions=9.3" -F "visibility=true"
+	curl -u "$(SPLUNKBASE_CREDS)" --request POST https://splunkbase.splunk.com/api/v1/app/7602/new_release/ -F "files[]=@./output/flare.tar.gz" -F "filename=flare.tar.gz" -F "splunk_versions=9.4" -F "visibility=true"
 
 .PHONY: validate
 validate: venv-tools

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Requirements
 
-At the time of this writing, Splunk Enterprise is at version 9.3.0. This version of splunk requires Python v3.9.
+At the time of this writing, Splunk Enterprise is at version 9.4.0. This version of splunk requires Python v3.9.
 
 ## Installation
 

--- a/packages/flare/src/main/resources/splunk/default/inputs.conf
+++ b/packages/flare/src/main/resources/splunk/default/inputs.conf
@@ -1,6 +1,6 @@
 [script://$SPLUNK_HOME/etc/apps/flare/bin/cron_job_ingest_events.py]
 interval = 0 0 1 1 *
-python.version = python3
+python.version = python3.9
 index = flare
 source = flare
 sourcetype = flare_json

--- a/packages/flare/src/main/resources/splunk/default/restmap.conf
+++ b/packages/flare/src/main/resources/splunk/default/restmap.conf
@@ -1,19 +1,19 @@
 [script:flare_external_requests_api_key_validation]
 match=/fetch_api_key_validation
 handler=flare_external_requests.FlareValidateApiKey
-python.version = python3
+python.version = python3.9
 
 [script:flare_external_requests_user_tenants]
 match=/fetch_user_tenants
 handler=flare_external_requests.FlareUserTenants
-python.version = python3
+python.version = python3.9
 
 [script:flare_external_requests_severity_filters]
 match=/fetch_severity_filters
 handler=flare_external_requests.FlareSeverityFilters
-python.version = python3
+python.version = python3.9
 
 [script:flare_external_requests_source_type_filters]
 match=/fetch_source_type_filters
 handler=flare_external_requests.FlareSourceTypeFilters
-python.version = python3
+python.version = python3.9

--- a/requirements.tools.txt
+++ b/requirements.tools.txt
@@ -1,6 +1,6 @@
 pytest==8.3.2
 mypy==1.12.1
 ruff==0.7.0
-splunk-appinspect==3.8.0
+splunk-appinspect==3.9.1
 isort==5.13.2
 freezegun==1.5.1


### PR DESCRIPTION
If a customer needs to force a custom python version for their application to run, this will make sure our scripts will still run using Python 3.9