### PR TITLE
Revert "Adds check for python versions below 3.9 and bails out if tru…

### DIFF
--- a/packages/flare/bin/cron_job_ingest_events.py
+++ b/packages/flare/bin/cron_job_ingest_events.py
@@ -1,12 +1,6 @@
-import sys
-
-
-if sys.version_info < (3, 9):
-    sys.exit("Error: This application requires Python 3.9 or higher.")
-
-
 import json
 import os
+import sys
 
 from datetime import date
 from datetime import datetime


### PR DESCRIPTION
…e (#81)"

This reverts commit c2132f718a8471cebff7437b7f709b174f2c0d19.

@aviau I realized that this isn't going to work because we end up getting a syntax errors before this is ever run.