### PR TITLE
Fixes Makefile publish target  credential issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Package and Publish
         run: |
           make package
-          SPLUNKBASE_CREDS="${{ secrets.SPLUNKBASE_CREDS }}" make publish
+          SPLUNKBASE_CREDS='${{ secrets.SPLUNKBASE_CREDS }}' make publish

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ package: packages/flare/bin/vendor
 
 .PHONY: publish
 publish: output/flare.tar.gz
-	curl -u "$(SPLUNKBASE_CREDS)" --request POST https://splunkbase.splunk.com/api/v1/app/7602/new_release/ -F "files[]=@./output/flare.tar.gz" -F "filename=flare.tar.gz" -F "splunk_versions=9.3" -F "visibility=true"
+	curl -u $$SPLUNKBASE_CREDS --request POST https://splunkbase.splunk.com/api/v1/app/7602/new_release/ -F "files[]=@./output/flare.tar.gz" -F "filename=flare.tar.gz" -F "splunk_versions=9.3" -F "visibility=true"
 
 .PHONY: validate
 validate: venv-tools


### PR DESCRIPTION
**Problem**

We changed the Splunk app ownership from the Splunk account `integrations@flare.systems` to the Splunk account `integrations+splunk@flare.io`. This means that we have to update the SPLUNK_CREDS Github secret with the new credentials. The password in these new credentials contained the characters `$^` . When these credentials were passed into the Makefile, Make would substitute the `$^` with the Makefile target's first dependency. So the curl would end up like the following:

<img width="855" alt="Screenshot 2025-02-10 at 2 34 27 PM" src="https://github.com/user-attachments/assets/bcab8d10-31bc-4ffa-b389-6a8f78db2036" />

Obviously, the publish failed.

**Solution**
One solution is to change the password removing those special characters, but this is fragile because it could happen again in the future. 

The solution was as follows:

Instead of doing: `curl -u "$(SPLUNKBASE_CREDS)" ...` 

We do: `curl -u $$SPLUNKBASE_CREDS ...` 

We also had to alter the publish.yml Github workflow to use single quotes instead of double as the double quotes would result in everything from the $ onward from being omitted. Bash was consuming it. 

