### PR TITLE
Sets asc order on event request and start_date is now - 30 days

### DIFF
--- a/packages/flare/bin/cron_job_ingest_events.py
+++ b/packages/flare/bin/cron_job_ingest_events.py
@@ -8,8 +8,9 @@ if sys.version_info < (3, 9):
 import json
 import os
 
-from datetime import date
 from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 from typing import Any
 from typing import Iterator
 from typing import Optional
@@ -204,13 +205,13 @@ def get_next(kvstore: KVStoreCollections, tenant_id: int) -> Optional[str]:
     )
 
 
-def get_start_date(kvstore: KVStoreCollections) -> Optional[date]:
+def get_start_date(kvstore: KVStoreCollections) -> Optional[datetime]:
     start_date = get_collection_value(
         kvstore=kvstore, key=CollectionKeys.START_DATE.value
     )
     if start_date:
         try:
-            return date.fromisoformat(start_date)
+            return datetime.fromisoformat(start_date)
         except Exception:
             pass
     return None
@@ -255,7 +256,7 @@ def save_last_ingested_tenant_id(kvstore: KVStoreCollections, tenant_id: int) ->
         save_collection_value(
             kvstore=kvstore,
             key=CollectionKeys.START_DATE.value,
-            value=date.today().isoformat(),
+            value=(datetime.now(timezone.utc) - timedelta(days=30)).isoformat(),
         )
 
     save_collection_value(

--- a/packages/flare/bin/flare.py
+++ b/packages/flare/bin/flare.py
@@ -8,7 +8,9 @@ if sys.version_info < (3, 9):
 import requests
 import time
 
-from datetime import date
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 from logger import Logger
 from typing import Any
 from typing import Dict
@@ -55,7 +57,7 @@ class FlareAPI(AuthBase):
         self,
         *,
         next: Optional[str] = None,
-        start_date: Optional[date] = None,
+        start_date: Optional[datetime] = None,
         ingest_full_event_data: bool,
         severities: list[str],
         source_types: list[str],
@@ -81,17 +83,18 @@ class FlareAPI(AuthBase):
         self,
         *,
         next: Optional[str] = None,
-        start_date: Optional[date] = None,
+        start_date: Optional[datetime] = None,
         severities: list[str],
         source_types: list[str],
     ) -> Iterator[requests.Response]:
         data: Dict[str, Any] = {
             "from": next if next else None,
+            "order": "asc",
             "filters": {
                 "materialized_at": {
                     "gte": start_date.isoformat()
                     if start_date
-                    else date.today().isoformat()
+                    else (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
                 },
             },
         }


### PR DESCRIPTION
30 days before today:

<img width="755" alt="Screenshot 2025-02-15 at 5 08 12 PM" src="https://github.com/user-attachments/assets/527f5c2c-4bed-4e69-b672-63a7b589d2ed" />
