### PR TITLE
Sets python.version = python3.9 in app.conf

### DIFF
--- a/packages/flare/src/main/resources/splunk/default/app.conf
+++ b/packages/flare/src/main/resources/splunk/default/app.conf
@@ -10,6 +10,7 @@ company = Flare Systems, Inc.
 id = flare
 
 [install]
+python.version = python3.9
 state_change_requires_restart = true
 is_configured = 0
 build = 6


### PR DESCRIPTION
Based on feedback received from Marco at MSC, we can force the app to use python 3.9 in splunk while other apps use 3.7 or others.