### PR TITLE
Updates appinspect from v3.8.0 to v3.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ venv: requirements.txt
 	@rm -rf packages/flare/bin/vendor/bin
 	@rm -rf packages/flare/bin/vendor/packaging
 	@rm -rf packages/flare/bin/vendor/*-stubs
+	@rm -rf packages/flare/bin/vendor/charset_normalizer/md.cpython-39-x86_64-linux-gnu.so
+	@rm -rf packages/flare/bin/vendor/charset_normalizer/md__mypyc.cpython-39-x86_64-linux-gnu.so
 
 venv-tools: requirements.tools.txt venv
 	rm -rf venv-tools

--- a/requirements.tools.txt
+++ b/requirements.tools.txt
@@ -1,6 +1,6 @@
 pytest==8.3.2
 mypy==1.12.1
 ruff==0.7.0
-splunk-appinspect==3.8.0
+splunk-appinspect==3.9.1
 isort==5.13.2
 freezegun==1.5.1


### PR DESCRIPTION
This did not change the results regard python.version = python3 in inputs.conf and restmap.conf, but might as well update it. 