### PR TITLE
handle errors while fetching full events

### DIFF
--- a/packages/flare/bin/flare.py
+++ b/packages/flare/bin/flare.py
@@ -47,7 +47,11 @@ def get_flare_api_client(
 
 class FlareAPI(AuthBase):
     def __init__(
-        self, *, api_key: str, tenant_id: Optional[int] = None, logger: Logger
+        self,
+        *,
+        api_key: str,
+        tenant_id: Optional[int] = None,
+        logger: Logger,
     ) -> None:
         self.flare_client = get_flare_api_client(
             api_key=api_key,
@@ -117,8 +121,8 @@ class FlareAPI(AuthBase):
             time.sleep(1)
 
     def _fetch_full_event_from_uid(self, *, uid: str) -> dict:
-        NUMBER_OF_RETRIES = 3
-        for current_try in range(NUMBER_OF_RETRIES):
+        number_of_retries = 3
+        for current_try in range(number_of_retries):
             try:
                 event_response = self.flare_client.get(
                     url=f"/firework/v2/activities/{uid}"
@@ -127,12 +131,12 @@ class FlareAPI(AuthBase):
             except Exception as e:
                 time.sleep(1)
                 self.logger.info(
-                    f"Failed to fetch event {current_try + 1}/{NUMBER_OF_RETRIES} retries: {e}"
+                    f"Failed to fetch event {current_try + 1}/{number_of_retries} retries: {e}"
                 )
                 continue
             return event_response.json()["activity"]
         raise Exception(
-            f"failed to fetch full event data for {uid} after {NUMBER_OF_RETRIES} tries"
+            f"failed to fetch full event data for {uid} after {number_of_retries} tries"
         )
 
     def fetch_api_key_validation(self) -> requests.Response:

--- a/packages/flare/bin/flare_external_requests.py
+++ b/packages/flare/bin/flare_external_requests.py
@@ -21,13 +21,14 @@ from logger import Logger
 
 class FlareValidateApiKey(splunk.rest.BaseRestHandler):
     def handle_POST(self) -> None:
+        logger = Logger(class_name=__file__)
         payload = self.request["payload"]
         params = parse.parse_qs(payload)
 
         if "apiKey" not in params:
             raise Exception("API Key is required")
 
-        flare_api = FlareAPI(api_key=params["apiKey"][0])
+        flare_api = FlareAPI(api_key=params["apiKey"][0], logger=logger)
         flare_api.fetch_api_key_validation()
         self.response.setHeader("Content-Type", "application/json")
         self.response.write(json.dumps({}))
@@ -42,7 +43,7 @@ class FlareUserTenants(splunk.rest.BaseRestHandler):
         if "apiKey" not in params:
             raise Exception("API Key is required")
 
-        flare_api = FlareAPI(api_key=params["apiKey"][0])
+        flare_api = FlareAPI(api_key=params["apiKey"][0], logger=logger)
         response = flare_api.fetch_tenants()
         response_json = response.json()
         logger.debug(f"FlareUserTenants: {response_json}")
@@ -59,7 +60,7 @@ class FlareSeverityFilters(splunk.rest.BaseRestHandler):
         if "apiKey" not in params:
             raise Exception("API Key is required")
 
-        flare_api = FlareAPI(api_key=params["apiKey"][0])
+        flare_api = FlareAPI(api_key=params["apiKey"][0], logger=logger)
         response = flare_api.fetch_filters_severity()
         response_json = response.json()
         logger.debug(f"FlareSeverityFilters: {response_json}")
@@ -76,7 +77,7 @@ class FlareSourceTypeFilters(splunk.rest.BaseRestHandler):
         if "apiKey" not in params:
             raise Exception("API Key is required")
 
-        flare_api = FlareAPI(api_key=params["apiKey"][0])
+        flare_api = FlareAPI(api_key=params["apiKey"][0], logger=logger)
         response = flare_api.fetch_filters_source_type()
         response_json = response.json()
         logger.debug(f"FlareSourceTypeFilters: {response_json}")

--- a/packages/flare/tests/bin/test_flare_wrapper.py
+++ b/packages/flare/tests/bin/test_flare_wrapper.py
@@ -1,191 +1,15 @@
-import os
 import pytest
 import requests_mock
-import sys
 
-from typing import Any
-from unittest.mock import MagicMock
-from unittest.mock import Mock
-from unittest.mock import PropertyMock
-from unittest.mock import call
-from unittest.mock import patch
-
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../bin"))
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../bin/vendor"))
+from conftest import FakeLogger
 from flare import FlareAPI
+from typing import Any
 
 
-@patch("flare.FlareAPI._fetch_full_event_from_uid")
-@patch("flare.FlareAPI._fetch_event_feed_metadata")
 def test_flare_full_data_without_metadata(
-    fetch_event_feed_metadata_mock: MagicMock,
-    fetch_full_event_from_uid_mock: MagicMock,
+    logger: FakeLogger,
+    disable_sleep: Any,
 ) -> None:
-    expected_return_value = {
-        "next": "some_next_value",
-        "items": [
-            {
-                "bad_data": "foo",
-            },
-            {
-                "bad_data": "bar",
-            },
-        ],
-    }
-
-    response_mock = Mock()
-    type(response_mock).status_code = PropertyMock(return_value=200)
-    response_mock.json.return_value = expected_return_value
-    fetch_event_feed_metadata_mock.return_value = iter([response_mock])
-
-    flare_api = FlareAPI(api_key="some_key", tenant_id=111)
-
-    events: list[dict] = []
-    for event, next_token in flare_api.fetch_feed_events(
-        next=None,
-        start_date=None,
-        ingest_full_event_data=False,
-        severities=[],
-        source_types=[],
-    ):
-        assert next_token == expected_return_value["next"]
-        events.append(event)
-
-    for i in range(len(events)):
-        assert events[i] == expected_return_value["items"][i]
-
-    fetch_full_event_from_uid_mock.assert_not_called()
-
-
-@patch("flare.FlareAPI._fetch_full_event_from_uid")
-@patch("flare.FlareAPI._fetch_event_feed_metadata")
-@patch("time.sleep", return_value=None)
-def test_flare_full_data_with_metadata(
-    sleep: Any,
-    fetch_event_feed_metadata_mock: MagicMock,
-    fetch_full_event_from_uid_mock: MagicMock,
-) -> None:
-    expected_return_value = {
-        "next": "some_next_value",
-        "items": [
-            {
-                "metadata": {"uid": "some_uid"},
-                "data": "foo",
-            },
-            {
-                "metadata": {"uid": "some_other_uid"},
-                "data": "bar",
-            },
-        ],
-    }
-
-    expected_full_data_value = {
-        "metadata": {
-            "uid": "some_uid",
-            "materialized_at": "2024-11-08T19:12:04Z",
-            "type": "chat_message",
-            "severity": "low",
-        },
-        "tenant_metadata": {"severity": None, "notes": None, "tags": []},
-        "identifiers": [{"id": 31337, "name": "credit card"}],
-        "highlights": {
-            "2_message": ["this is a leaked message"],
-            "3_message": ["this is a leaked message"],
-        },
-    }
-
-    response_mock = Mock()
-    type(response_mock).status_code = PropertyMock(return_value=200)
-    response_mock.json.return_value = expected_return_value
-
-    fetch_event_feed_metadata_mock.return_value = iter([response_mock])
-    flare_api = FlareAPI(api_key="some_key", tenant_id=111)
-
-    fetch_full_event_from_uid_mock.return_value = expected_full_data_value
-
-    events: list[dict] = []
-    for event, next_token in flare_api.fetch_feed_events(
-        next=None,
-        start_date=None,
-        ingest_full_event_data=True,
-        severities=[],
-        source_types=[],
-    ):
-        assert next_token == expected_return_value["next"]
-        events.append(event)
-
-    for i in range(len(events)):
-        assert events[i] == expected_full_data_value
-
-    fetch_event_feed_metadata_mock.assert_called_once()
-
-
-@patch("flare.FlareAPI._fetch_full_event_from_uid")
-@patch("flare.FlareAPI._fetch_event_feed_metadata")
-def test_flare_full_data_with_metadata_and_exception(
-    fetch_event_feed_metadata_mock: MagicMock,
-    fetch_full_event_from_uid_mock: MagicMock,
-) -> None:
-    expected_return_value = {
-        "next": "some_next_value",
-        "items": [
-            {
-                "not_metadata": {"uid": "some_uid"},
-            },
-            {
-                "metadata": {"uid": "some_other_uid"},
-                "bad_data": "bar",
-            },
-        ],
-    }
-
-    response_mock = Mock()
-    type(response_mock).status_code = PropertyMock(return_value=200)
-    response_mock.json.return_value = expected_return_value
-
-    fetch_event_feed_metadata_mock.return_value = iter([response_mock])
-    flare_api = FlareAPI(api_key="some_key", tenant_id=111)
-
-    with pytest.raises(KeyError, match="metadata"):
-        next(
-            flare_api.fetch_feed_events(
-                next=None,
-                start_date=None,
-                ingest_full_event_data=True,
-                severities=[],
-                source_types=[],
-            )
-        )
-
-    fetch_event_feed_metadata_mock.assert_called_once()
-    fetch_full_event_from_uid_mock.assert_not_called()
-
-
-@patch("time.sleep", return_value=None)
-@patch("flare.FlareAPI._fetch_event_feed_metadata")
-def test_flare_full_data_retry_exception(
-    fetch_event_feed_metadata_mock: MagicMock,
-    sleep_mock: MagicMock,
-) -> None:
-    expected_return_value = {
-        "next": "some_next_value",
-        "items": [
-            {
-                "metadata": {"uid": "some_uid"},
-                "data": "some_data",
-            },
-        ],
-    }
-
-    response_mock = Mock()
-    type(response_mock).status_code = PropertyMock(return_value=200)
-    response_mock.json.return_value = expected_return_value
-    fetch_event_feed_metadata_mock.return_value = iter([response_mock])
-
-    flare_api = FlareAPI(api_key="some_key", tenant_id=111)
-    flare_api.logger = MagicMock()  # logger refuses to patch ¯\_(ツ)_/¯
-
     with requests_mock.Mocker() as mocker:
         mocker.register_uri(
             "POST",
@@ -193,15 +17,227 @@ def test_flare_full_data_retry_exception(
             status_code=200,
             json={"token": "access_token"},
         )
+
+        tenant_resp_page_1: Any = {
+            "next": "some_next_value",
+            "items": [
+                {"metadata": {"uid": "some_uid_1"}},
+                {"metadata": {"uid": "some_uid_2"}},
+            ],
+        }
+
+        tenant_resp_page_2: Any = {
+            "next": None,
+            "items": [],
+        }
+
+        mocker.register_uri(
+            "POST",
+            "https://api.flare.io/firework/v4/events/tenant/_search",
+            status_code=200,
+            json=tenant_resp_page_1,
+        )
+
+        mocker.register_uri(
+            "POST",
+            "https://api.flare.io/firework/v4/events/tenant/_search",
+            additional_matcher=lambda request: request.json().get("from")
+            == "some_next_value",
+            status_code=200,
+            json=tenant_resp_page_2,
+        )
+
+        mock_full_event = mocker.register_uri(
+            "GET",
+            "https://api.flare.io/firework/v2/activities/some_uid_1",
+            status_code=200,
+            json={},
+        )
+
+        flare_api = FlareAPI(api_key="some_key", tenant_id=111, logger=logger)
+
+        events: list[dict] = []
+        for event, next_token in flare_api.fetch_feed_events(
+            next=None,
+            start_date=None,
+            ingest_full_event_data=False,
+            severities=[],
+            source_types=[],
+        ):
+            assert next_token == tenant_resp_page_1["next"]
+            events.append(event)
+
+        assert events == tenant_resp_page_1["items"]
+        assert not mock_full_event.called
+
+
+def test_flare_full_data_with_metadata(
+    logger: FakeLogger,
+    disable_sleep: Any,
+) -> None:
+    with requests_mock.Mocker() as mocker:
+        mocker.register_uri(
+            "POST",
+            "https://api.flare.io/tokens/generate",
+            status_code=200,
+            json={"token": "access_token"},
+        )
+
+        tenant_resp_page_1: Any = {
+            "next": "some_next_value",
+            "items": [
+                {"metadata": {"uid": "some_uid_1"}},
+                {"metadata": {"uid": "some_uid_2"}},
+            ],
+        }
+
+        tenant_resp_page_2: Any = {
+            "next": None,
+            "items": [],
+        }
+
+        mocker.register_uri(
+            "POST",
+            "https://api.flare.io/firework/v4/events/tenant/_search",
+            status_code=200,
+            json=tenant_resp_page_1,
+        )
+
+        mocker.register_uri(
+            "POST",
+            "https://api.flare.io/firework/v4/events/tenant/_search",
+            additional_matcher=lambda request: request.json().get("from")
+            == "some_next_value",
+            status_code=200,
+            json=tenant_resp_page_2,
+        )
+
+        expected_full_event_resp = [
+            {
+                "metadata": {
+                    "uid": "some_uid_1",
+                },
+            },
+            {
+                "metadata": {
+                    "uid": "some_uid_2",
+                },
+            },
+        ]
+
+        mock_full_event_1 = mocker.register_uri(
+            "GET",
+            "https://api.flare.io/firework/v2/activities/some_uid_1",
+            status_code=200,
+            json={"activity": expected_full_event_resp[0]},
+        )
+
+        mock_full_event_2 = mocker.register_uri(
+            "GET",
+            "https://api.flare.io/firework/v2/activities/some_uid_2",
+            status_code=200,
+            json={"activity": expected_full_event_resp[1]},
+        )
+
+        flare_api = FlareAPI(api_key="some_key", tenant_id=111, logger=logger)
+
+        events: list[dict] = []
+        for event, next_token in flare_api.fetch_feed_events(
+            next=None,
+            start_date=None,
+            ingest_full_event_data=True,
+            severities=[],
+            source_types=[],
+        ):
+            assert next_token == tenant_resp_page_1["next"]
+            events.append(event)
+
+        for i in range(len(events)):
+            assert events[i] == expected_full_event_resp[i]
+
+        assert mock_full_event_1.called
+        assert mock_full_event_2.called
+
+
+def test_flare_full_data_with_metadata_and_exception(
+    logger: FakeLogger,
+    disable_sleep: Any,
+) -> None:
+    with requests_mock.Mocker() as mocker:
+        mocker.register_uri(
+            "POST",
+            "https://api.flare.io/tokens/generate",
+            status_code=200,
+            json={"token": "access_token"},
+        )
+
+        tenant_resp_page_1 = {
+            "next": "some_next_value",
+            "items": [
+                {"not_metadata": {"uid": "some_uid_1"}},
+                {"metadata": {"uid": "some_uid_2"}},
+            ],
+        }
+
+        mocker.register_uri(
+            "POST",
+            "https://api.flare.io/firework/v4/events/tenant/_search",
+            status_code=200,
+            json=tenant_resp_page_1,
+        )
+
+        flare_api = FlareAPI(api_key="some_key", tenant_id=111, logger=logger)
+
+        with pytest.raises(KeyError, match="metadata"):
+            next(
+                flare_api.fetch_feed_events(
+                    next=None,
+                    start_date=None,
+                    ingest_full_event_data=True,
+                    severities=[],
+                    source_types=[],
+                )
+            )
+
+
+def test_flare_full_data_retry_exception(
+    logger: FakeLogger,
+    disable_sleep: Any,
+) -> None:
+    with requests_mock.Mocker() as mocker:
+        mocker.register_uri(
+            "POST",
+            "https://api.flare.io/tokens/generate",
+            status_code=200,
+            json={"token": "access_token"},
+        )
+
+        tenant_resp_page_1 = {
+            "next": "some_next_value",
+            "items": [
+                {"metadata": {"uid": "some_uid_1"}},
+                {"metadata": {"uid": "some_uid_2"}},
+            ],
+        }
+
+        mocker.register_uri(
+            "POST",
+            "https://api.flare.io/firework/v4/events/tenant/_search",
+            status_code=200,
+            json=tenant_resp_page_1,
+        )
+
         mocker.register_uri(
             "GET",
-            "https://api.flare.io/firework/v2/activities/some_uid",
+            "https://api.flare.io/firework/v2/activities/some_uid_1",
             status_code=500,
         )
 
+        flare_api = FlareAPI(api_key="some_key", tenant_id=111, logger=logger)
+
         with pytest.raises(
             Exception,
-            match="failed to fetch full event data for some_uid after 3 tries",
+            match="failed to fetch full event data for some_uid_1 after 3 tries",
         ):
             next(
                 flare_api.fetch_feed_events(
@@ -213,19 +249,8 @@ def test_flare_full_data_retry_exception(
                 )
             )
 
-            fetch_event_feed_metadata_mock.assert_called_once()
-
-        flare_api.logger.debug.assert_has_calls(
-            [
-                call(expected_return_value),
-                call(
-                    "Failed to fetch event: 500 Server Error: None for url: https://api.flare.io/firework/v2/activities/some_uid"
-                ),
-                call(
-                    "Failed to fetch event: 500 Server Error: None for url: https://api.flare.io/firework/v2/activities/some_uid"
-                ),
-                call(
-                    "Failed to fetch event: 500 Server Error: None for url: https://api.flare.io/firework/v2/activities/some_uid"
-                ),
-            ]
-        )
+        assert logger.messages == [
+            "INFO: Failed to fetch event 1/3 retries: 500 Server Error: None for url: https://api.flare.io/firework/v2/activities/some_uid_1",
+            "INFO: Failed to fetch event 2/3 retries: 500 Server Error: None for url: https://api.flare.io/firework/v2/activities/some_uid_1",
+            "INFO: Failed to fetch event 3/3 retries: 500 Server Error: None for url: https://api.flare.io/firework/v2/activities/some_uid_1",
+        ]

--- a/packages/flare/tests/bin/test_flare_wrapper.py
+++ b/packages/flare/tests/bin/test_flare_wrapper.py
@@ -1,11 +1,13 @@
 import os
 import pytest
+import requests_mock
 import sys
 
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import PropertyMock
+from unittest.mock import call
 from unittest.mock import patch
 
 
@@ -119,7 +121,7 @@ def test_flare_full_data_with_metadata(
     fetch_event_feed_metadata_mock.assert_called_once()
 
 
-@patch("flare.FlareAPI._fetch_full_event_from_uid", side_effect=Exception)
+@patch("flare.FlareAPI._fetch_full_event_from_uid")
 @patch("flare.FlareAPI._fetch_event_feed_metadata")
 def test_flare_full_data_with_metadata_and_exception(
     fetch_event_feed_metadata_mock: MagicMock,
@@ -157,3 +159,73 @@ def test_flare_full_data_with_metadata_and_exception(
         )
 
     fetch_event_feed_metadata_mock.assert_called_once()
+    fetch_full_event_from_uid_mock.assert_not_called()
+
+
+@patch("time.sleep", return_value=None)
+@patch("flare.FlareAPI._fetch_event_feed_metadata")
+def test_flare_full_data_retry_exception(
+    fetch_event_feed_metadata_mock: MagicMock,
+    sleep_mock: MagicMock,
+) -> None:
+    expected_return_value = {
+        "next": "some_next_value",
+        "items": [
+            {
+                "metadata": {"uid": "some_uid"},
+                "data": "some_data",
+            },
+        ],
+    }
+
+    response_mock = Mock()
+    type(response_mock).status_code = PropertyMock(return_value=200)
+    response_mock.json.return_value = expected_return_value
+    fetch_event_feed_metadata_mock.return_value = iter([response_mock])
+
+    flare_api = FlareAPI(api_key="some_key", tenant_id=111)
+    flare_api.logger = MagicMock()  # logger refuses to patch ¯\_(ツ)_/¯
+
+    with requests_mock.Mocker() as mocker:
+        mocker.register_uri(
+            "POST",
+            "https://api.flare.io/tokens/generate",
+            status_code=200,
+            json={"token": "access_token"},
+        )
+        mocker.register_uri(
+            "GET",
+            "https://api.flare.io/firework/v2/activities/some_uid",
+            status_code=500,
+        )
+
+        with pytest.raises(
+            Exception,
+            match="failed to fetch full event data for some_uid after 3 tries",
+        ):
+            next(
+                flare_api.fetch_feed_events(
+                    next=None,
+                    start_date=None,
+                    ingest_full_event_data=True,
+                    severities=[],
+                    source_types=[],
+                )
+            )
+
+            fetch_event_feed_metadata_mock.assert_called_once()
+
+        flare_api.logger.debug.assert_has_calls(
+            [
+                call(expected_return_value),
+                call(
+                    "Failed to fetch event: 500 Server Error: None for url: https://api.flare.io/firework/v2/activities/some_uid"
+                ),
+                call(
+                    "Failed to fetch event: 500 Server Error: None for url: https://api.flare.io/firework/v2/activities/some_uid"
+                ),
+                call(
+                    "Failed to fetch event: 500 Server Error: None for url: https://api.flare.io/firework/v2/activities/some_uid"
+                ),
+            ]
+        )

--- a/packages/flare/tests/bin/test_ingest_events.py
+++ b/packages/flare/tests/bin/test_ingest_events.py
@@ -1,16 +1,9 @@
 import datetime
-import os
 import pytest
-import sys
 
 from conftest import FakeFlareAPI
 from conftest import FakeLogger
 from conftest import FakeStoragePasswords
-from data_store import ConfigDataStore
-from freezegun import freeze_time
-
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../bin"))
 from constants import CRON_JOB_THRESHOLD_SINCE_LAST_FETCH
 from constants import PasswordKeys
 from cron_job_ingest_events import fetch_feed
@@ -18,6 +11,8 @@ from cron_job_ingest_events import get_api_key
 from cron_job_ingest_events import get_ingest_full_event_data
 from cron_job_ingest_events import get_tenant_ids
 from cron_job_ingest_events import main
+from data_store import ConfigDataStore
+from freezegun import freeze_time
 
 
 @pytest.mark.parametrize("storage_passwords", [[]], indirect=True)

--- a/requirements.tools.txt
+++ b/requirements.tools.txt
@@ -4,3 +4,5 @@ ruff==0.7.0
 splunk-appinspect==3.9.1
 isort==5.13.2
 freezegun==1.5.1
+
+requests-mock==1.12.1

--- a/requirements.tools.txt
+++ b/requirements.tools.txt
@@ -4,5 +4,4 @@ ruff==0.7.0
 splunk-appinspect==3.9.1
 isort==5.13.2
 freezegun==1.5.1
-
 requests-mock==1.12.1


### PR DESCRIPTION

It seems that we sometimes get no activity data back from the `firework/v2/activities/<uid>` endpoint. I added some logging in to spot this:
<img width="755" alt="Screenshot 2025-02-20 at 10 41 22 AM" src="https://github.com/user-attachments/assets/0cfd6bd8-8b43-432b-8745-ed4b31be19ef" />
<img width="757" alt="Screenshot 2025-02-20 at 10 41 31 AM" src="https://github.com/user-attachments/assets/4cd59b0b-4dc3-45ab-81df-8d58fe56ba2e" />
<img width="509" alt="Screenshot 2025-02-20 at 10 41 41 AM" src="https://github.com/user-attachments/assets/17eca8a6-b632-4b78-889a-30dd73266ed4" />

This seems to happen fairly often. We get a next token, but nothing for the data. Assuming this is to be expected and to prevent the Splunk app from sending {} to the index, I've added a check to prevent this. 

@aviau Does this make sense and are you OK with the fix? Don't read too much into `Failed to fetch event with uid:`. That's just my logging. The request succeeded.

We get a 500:
<img width="759" alt="Screenshot 2025-02-20 at 1 02 57 PM" src="https://github.com/user-attachments/assets/1199ccaa-6785-4cbe-9a6f-bfafd0b7d66c" />

I'm thinking we need retries here. 