### PR TITLE
Fixes lint warnings for the .ruff.toml file settings

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,3 +1,4 @@
+[lint]
 extend-select = [
     "I",
     "C411",
@@ -25,7 +26,7 @@ ignore = [
     "F405",
 ]
 
-[isort]
+[lint.isort]
 force-single-line = true
 no-sections = true
 lines-after-imports = 2


### PR DESCRIPTION
<img width="1036" alt="Screenshot 2025-02-20 at 3 14 53 PM" src="https://github.com/user-attachments/assets/c89eacb6-34e0-4959-a0ee-a8e6c08c72f3" />
