### PR TITLE
Fixes 'Line breaking regex has no capturing groups' error

### DIFF
--- a/packages/flare/src/main/resources/splunk/default/props.conf
+++ b/packages/flare/src/main/resources/splunk/default/props.conf
@@ -1,9 +1,8 @@
 [flare_json]
 DATETIME_CONFIG = CURRENT
 BREAK_ONLY_BEFORE = ^{
-LINE_BREAKER = ^{
 NO_BINARY_CHECK = true
-SHOULD_LINEMERGE = false
+SHOULD_LINEMERGE = true
 TRUNCATE = 0
 category = Structured
 description = Flare's JSON source type


### PR DESCRIPTION
We get a lot of these errors in the internal index:

<img width="1230" alt="Screenshot 2025-02-21 at 3 12 22 PM" src="https://github.com/user-attachments/assets/15bd971b-a413-461b-a79f-7050313a4b5a" />
 
Applying the changes suggested [here](https://community.splunk.com/t5/Getting-Data-In/Why-does-linebreaking-regex-have-no-capturing-groups/m-p/643941/highlight/true#M109661) fixes the issue and events are still ingested and parsed as expected.

<img width="1249" alt="Screenshot 2025-02-21 at 4 01 51 PM" src="https://github.com/user-attachments/assets/b78563a3-38e2-4b3d-bfb7-096660d44108" />

@TyMarc Would especially like to get your eyes on this since you created the custom flare_json source. Thanks.
