### PR TITLE
Add multi tenancy support

### DIFF
--- a/packages/flare/bin/constants.py
+++ b/packages/flare/bin/constants.py
@@ -21,6 +21,9 @@ class DataStoreKeys(Enum):
     START_DATE = "start_date"
     TIMESTAMP_LAST_FETCH = "timestamp_last_fetch"
 
+    SECTION_METADATA = "metadata"
+    SECTION_TENANT_DATA = "tenant_data"
+
     @staticmethod
     def get_next_token(tenant_id: int) -> str:
         return f"next_{tenant_id}"

--- a/packages/flare/bin/constants.py
+++ b/packages/flare/bin/constants.py
@@ -11,17 +11,20 @@ CRON_JOB_THRESHOLD_SINCE_LAST_FETCH = timedelta(minutes=10)
 
 class PasswordKeys(Enum):
     API_KEY = "api_key"
-    TENANT_ID = "tenant_id"
+    TENANT_IDS = "tenant_ids"
     INGEST_FULL_EVENT_DATA = "ingest_full_event_data"
     SEVERITIES_FILTER = "severities_filter"
     SOURCE_TYPES_FILTER = "source_types_filter"
 
 
 class DataStoreKeys(Enum):
-    LAST_INGESTED_TENANT_ID = "last_ingested_tenant_id"
     START_DATE = "start_date"
     TIMESTAMP_LAST_FETCH = "timestamp_last_fetch"
 
     @staticmethod
     def get_next_token(tenant_id: int) -> str:
         return f"next_{tenant_id}"
+
+    @staticmethod
+    def get_earliest_ingested(tenant_id: int) -> str:
+        return f"timestamp_earliest_ingested_{tenant_id}"

--- a/packages/flare/bin/cron_job_ingest_events.py
+++ b/packages/flare/bin/cron_job_ingest_events.py
@@ -52,9 +52,11 @@ def main(
 
     data_store.set_last_fetch(datetime.now(timezone.utc))
 
-    events_fetched_count = 0
+    total_events_fetched_count = 0
 
     for tenant_id in tenant_ids:
+        events_fetched_count = 0
+
         # The earliest ingested date serves as a low water mark to look
         # for identifiers 30 days prior to the day a tenant was first configured.
         start_date = data_store.get_earliest_ingested_by_tenant(tenant_id)
@@ -83,8 +85,10 @@ def main(
             print(json.dumps(event), flush=True)
 
             events_fetched_count += 1
+        logger.info(f"Fetched {events_fetched_count} events on tenant {tenant_id}")
+        total_events_fetched_count += events_fetched_count
 
-    logger.info(f"Fetched {events_fetched_count} events")
+    logger.info(f"Fetched {events_fetched_count} events across all tenants")
 
 
 def fetch_feed(

--- a/packages/flare/bin/cron_job_ingest_events.py
+++ b/packages/flare/bin/cron_job_ingest_events.py
@@ -97,9 +97,9 @@ def fetch_feed(
     flare_api_cls: type[FlareAPI],
     data_store: ConfigDataStore,
 ) -> Iterator[tuple[dict, str]]:
-    try:
-        flare_api: FlareAPI = flare_api_cls(api_key=api_key, tenant_id=tenant_id)
+    flare_api: FlareAPI = flare_api_cls(api_key=api_key, tenant_id=tenant_id)
 
+    try:
         next = data_store.get_next_by_tenant(tenant_id)
         start_date = data_store.get_earliest_ingested_by_tenant(tenant_id)
         logger.info(f"Fetching {tenant_id=}, {next=}, {start_date=}")

--- a/packages/flare/bin/data_store.py
+++ b/packages/flare/bin/data_store.py
@@ -20,10 +20,10 @@ class ConfigDataStore:
         config_store.read(config_path)
 
         # Add data sections
-        if "metadata" not in config_store.sections():
-            config_store.add_section("metadata")
-        if "tenant_data" not in config_store.sections():
-            config_store.add_section("tenant_data")
+        if DataStoreKeys.SECTION_METADATA.value not in config_store.sections():
+            config_store.add_section(DataStoreKeys.SECTION_METADATA.value)
+        if DataStoreKeys.SECTION_TENANT_DATA.value not in config_store.sections():
+            config_store.add_section(DataStoreKeys.SECTION_TENANT_DATA.value)
         self._store = config_store
 
     def _commit(self) -> None:
@@ -36,7 +36,9 @@ class ConfigDataStore:
     def get_last_fetch(self) -> Optional[datetime]:
         self._sync()
         last_fetched = self._store.get(
-            "metadata", DataStoreKeys.TIMESTAMP_LAST_FETCH.value, fallback=None
+            DataStoreKeys.SECTION_METADATA.value,
+            DataStoreKeys.TIMESTAMP_LAST_FETCH.value,
+            fallback=None,
         )
 
         if last_fetched:
@@ -48,7 +50,7 @@ class ConfigDataStore:
 
     def set_last_fetch(self, last_fetch: datetime) -> None:
         self._store.set(
-            "metadata",
+            DataStoreKeys.SECTION_METADATA.value,
             DataStoreKeys.TIMESTAMP_LAST_FETCH.value,
             last_fetch.isoformat(),
         )
@@ -57,7 +59,7 @@ class ConfigDataStore:
     def get_next_by_tenant(self, tenant_id: int) -> Optional[str]:
         self._sync()
         return self._store.get(
-            "tenant_data",
+            DataStoreKeys.SECTION_TENANT_DATA.value,
             DataStoreKeys.get_next_token(tenant_id=tenant_id),
             fallback=None,
         )
@@ -67,14 +69,16 @@ class ConfigDataStore:
             return
 
         self._store.set(
-            "tenant_data", DataStoreKeys.get_next_token(tenant_id=tenant_id), next
+            DataStoreKeys.SECTION_TENANT_DATA.value,
+            DataStoreKeys.get_next_token(tenant_id=tenant_id),
+            next,
         )
         self._commit()
 
     def get_earliest_ingested_by_tenant(self, tenant_id: int) -> Optional[datetime]:
         self._sync()
         earliest_ingested = self._store.get(
-            "tenant_data",
+            DataStoreKeys.SECTION_TENANT_DATA.value,
             DataStoreKeys.get_earliest_ingested(tenant_id=tenant_id),
             fallback=None,
         )
@@ -90,7 +94,7 @@ class ConfigDataStore:
         self, tenant_id: int, earliest_ingested: datetime
     ) -> None:
         self._store.set(
-            "tenant_data",
+            DataStoreKeys.SECTION_TENANT_DATA.value,
             DataStoreKeys.get_earliest_ingested(tenant_id=tenant_id),
             earliest_ingested.isoformat(),
         )

--- a/packages/flare/bin/flare_external_requests.py
+++ b/packages/flare/bin/flare_external_requests.py
@@ -90,13 +90,11 @@ class FlareIngestionStatus(splunk.rest.BaseRestHandler):
 
         data_store = ConfigDataStore()
         last_fetched_timestamp = data_store.get_last_fetch()
-        last_tenant_id = data_store.get_last_tenant_id()
 
         status_resp = {
             "last_fetched_at": last_fetched_timestamp.isoformat()
             if last_fetched_timestamp is not None
-            else None,
-            "last_tenant_id": last_tenant_id,
+            else None
         }
         logger.debug(f"FlareIngestionStatus: {status_resp}")
         self.response.setHeader("Content-Type", "application/json")

--- a/packages/flare/tests/bin/conftest.py
+++ b/packages/flare/tests/bin/conftest.py
@@ -116,7 +116,7 @@ def mock_env(mock_config_file: Path) -> Generator[None, None, None]:
 @pytest.fixture
 def data_store(mock_env: None) -> Generator[ConfigDataStore, None, None]:
     # Creates an instance of ConfigDataStore with mocked dependencies.
-    with mock.patch("configparser.ConfigParser.read") as mock_read:
+    with mock.patch("configparser.RawConfigParser.read") as mock_read:
         mock_read.return_value = None
         store = ConfigDataStore()
         store._commit = lambda: None

--- a/packages/flare/tests/bin/test_data_store.py
+++ b/packages/flare/tests/bin/test_data_store.py
@@ -3,17 +3,6 @@ from datetime import datetime
 from datetime import timezone
 
 
-def test_get_and_set_last_tenant_id(data_store: ConfigDataStore) -> None:
-    data_store.set_last_tenant_id(123)
-    assert data_store.get_last_tenant_id() == 123
-
-
-def test_get_and_set_start_date(data_store: ConfigDataStore) -> None:
-    date = datetime(2024, 3, 6, 12, 0, 0, tzinfo=timezone.utc)
-    data_store.set_start_date(date)
-    assert data_store.get_start_date() == date
-
-
 def test_get_and_set_last_fetch(data_store: ConfigDataStore) -> None:
     date = datetime(2024, 3, 6, 14, 0, 0, tzinfo=timezone.utc)
     data_store.set_last_fetch(date)
@@ -25,3 +14,10 @@ def test_get_and_set_next_by_tenant(data_store: ConfigDataStore) -> None:
     next_token = "next_token_value"
     data_store.set_next_by_tenant(tenant_id, next_token)
     assert data_store.get_next_by_tenant(tenant_id) == "next_token_value"
+
+
+def test_get_and_set_earliest_ingested_by_tenant(data_store: ConfigDataStore) -> None:
+    tenant_id = 789
+    date = datetime(2024, 3, 6, 14, 0, 0, tzinfo=timezone.utc)
+    data_store.set_earliest_ingested_by_tenant(tenant_id, date)
+    assert data_store.get_earliest_ingested_by_tenant(tenant_id) == date

--- a/packages/flare/tests/bin/test_ingest_events.py
+++ b/packages/flare/tests/bin/test_ingest_events.py
@@ -16,7 +16,7 @@ from constants import PasswordKeys
 from cron_job_ingest_events import fetch_feed
 from cron_job_ingest_events import get_api_key
 from cron_job_ingest_events import get_ingest_full_event_data
-from cron_job_ingest_events import get_tenant_id
+from cron_job_ingest_events import get_tenant_ids
 from cron_job_ingest_events import main
 
 
@@ -32,8 +32,8 @@ def test_get_api_key_expect_exception(storage_passwords: FakeStoragePasswords) -
     indirect=True,
 )
 def test_tenant_id_expect_exception(storage_passwords: FakeStoragePasswords) -> None:
-    with pytest.raises(Exception, match="Tenant ID not found"):
-        get_tenant_id(storage_passwords=storage_passwords)
+    with pytest.raises(Exception, match="Tenant IDs not found"):
+        get_tenant_ids(storage_passwords=storage_passwords)
 
 
 @pytest.mark.parametrize(
@@ -41,7 +41,7 @@ def test_tenant_id_expect_exception(storage_passwords: FakeStoragePasswords) -> 
     [
         [
             (PasswordKeys.API_KEY.value, "some_api_key"),
-            (PasswordKeys.TENANT_ID.value, 11111),
+            (PasswordKeys.TENANT_IDS.value, "[11111,22222]"),
         ],
     ],
     indirect=True,
@@ -50,7 +50,7 @@ def test_get_api_credentials_expect_api_key_and_tenant_id(
     storage_passwords: FakeStoragePasswords,
 ) -> None:
     assert get_api_key(storage_passwords=storage_passwords) == "some_api_key"
-    assert get_tenant_id(storage_passwords=storage_passwords) == 11111
+    assert get_tenant_ids(storage_passwords=storage_passwords) == [11111, 22222]
 
 
 def test_get_default_ingest_full_event_data_value(
@@ -91,7 +91,7 @@ def test_fetch_feed_expect_feed_response(
     [
         [
             (PasswordKeys.API_KEY.value, "some_api_key"),
-            (PasswordKeys.TENANT_ID.value, 11111),
+            (PasswordKeys.TENANT_IDS.value, "[11111]"),
         ]
     ],
     indirect=True,
@@ -122,7 +122,7 @@ def test_main_expect_early_return(
     [
         [
             (PasswordKeys.API_KEY.value, "some_api_key"),
-            (PasswordKeys.TENANT_ID.value, 11111),
+            (PasswordKeys.TENANT_IDS.value, "[11111,22222]"),
         ]
     ],
     indirect=True,
@@ -141,5 +141,6 @@ def test_main_expect_normal_run(
     )
     assert logger.messages == [
         "INFO: Fetching tenant_id=11111, next=None, start_date=FakeDatetime(1999, 12, 2, 0, 0, tzinfo=datetime.timezone.utc)",
-        "INFO: Fetched 2 events",
+        "INFO: Fetching tenant_id=22222, next=None, start_date=FakeDatetime(1999, 12, 2, 0, 0, tzinfo=datetime.timezone.utc)",
+        "INFO: Fetched 4 events",
     ]

--- a/packages/flare/tests/bin/test_ingest_events.py
+++ b/packages/flare/tests/bin/test_ingest_events.py
@@ -141,6 +141,8 @@ def test_main_expect_normal_run(
     )
     assert logger.messages == [
         "INFO: Fetching tenant_id=11111, next=None, start_date=FakeDatetime(1999, 12, 2, 0, 0, tzinfo=datetime.timezone.utc)",
+        "INFO: Fetched 2 events on tenant 11111",
         "INFO: Fetching tenant_id=22222, next=None, start_date=FakeDatetime(1999, 12, 2, 0, 0, tzinfo=datetime.timezone.utc)",
-        "INFO: Fetched 4 events",
+        "INFO: Fetched 2 events on tenant 22222",
+        "INFO: Fetched 2 events across all tenants",
     ]

--- a/packages/react-components/src/StatusScreen.tsx
+++ b/packages/react-components/src/StatusScreen.tsx
@@ -12,7 +12,6 @@ enum StatusItemKeys {
     START_DATE = 'start_date',
     LAST_FETCHED = 'timestamp_last_fetch',
     NEXT_TOKEN = 'next_token',
-    LAST_INGESTED_TENANT_ID = 'last_ingested_tenant_id',
     INDEX = 'index',
     VERSION = 'version',
 }
@@ -48,11 +47,6 @@ const StatusScreen: FC<{ theme: string }> = ({ theme }) => {
             ]);
 
             setAdvancedStatusItem([
-                {
-                    key: StatusItemKeys.LAST_INGESTED_TENANT_ID,
-                    name: 'Last Tenant ID Ingested',
-                    value: ingestionStatus.last_tenant_id || 'N/A',
-                },
                 {
                     key: StatusItemKeys.LAST_FETCHED,
                     name: 'Last moment the events were ingested',

--- a/packages/react-components/src/components/ConfigurationCompletedStep.tsx
+++ b/packages/react-components/src/components/ConfigurationCompletedStep.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from 'react';
 import {
-    fetchTenantId,
+    fetchTenantIds,
     fetchUserTenants,
     getFlareSearchDataUrl,
 } from '../utils/setupConfiguration';
@@ -18,24 +18,28 @@ const ConfigurationCompletedStep: FC<{
 }> = ({ apiKey, configurationStep, onEditConfigurationClick }) => {
     const [isInitializingData, setIsInitializingData] = useState(true);
     const [flareSearchUrl, setFlareSearchUrl] = useState('');
-    const [tenantName, setTenantName] = useState('');
+    const [tenantNames, setTenantNames] = useState('');
 
     useEffect(() => {
         if (configurationStep === ConfigurationStep.Completed) {
-            Promise.all([getFlareSearchDataUrl(), fetchTenantId(), fetchUserTenants(apiKey)]).then(
-                ([url, tenantId, userTenants]) => {
+            Promise.all([getFlareSearchDataUrl(), fetchTenantIds(), fetchUserTenants(apiKey)]).then(
+                ([url, tenantIds, userTenants]) => {
                     setFlareSearchUrl(url);
-                    setTenantName(
-                        userTenants.find((tenant: Tenant) => tenant.id === tenantId)?.name ||
-                            'unknown'
-                    );
+                    const tenantNameStrings = tenantIds
+                        .map(
+                            (tenantId) =>
+                                userTenants.find((tenant: Tenant) => tenant.id === tenantId)?.name
+                        )
+                        .filter(Boolean)
+                        .join(', ');
+                    setTenantNames(tenantNameStrings || 'Unknown');
                     setIsInitializingData(false);
                 }
             );
         } else {
             setIsInitializingData(true);
             setFlareSearchUrl('');
-            setTenantName('');
+            setTenantNames('');
         }
     }, [configurationStep, apiKey]);
 
@@ -51,8 +55,8 @@ const ConfigurationCompletedStep: FC<{
         <div>
             <h5>
                 {`You can now access `}
-                <b>{tenantName}</b>
-                {`'s Flare Data in Splunk.`}
+                <b>{tenantNames}</b>
+                {` Flare Data in Splunk.`}
             </h5>
             <div className="form-group">
                 <div className="button-group">

--- a/packages/react-components/src/components/TenantSelection.css
+++ b/packages/react-components/src/components/TenantSelection.css
@@ -1,0 +1,156 @@
+#tenant-container {
+    display: flex;
+    flex-direction: column;
+    margin-top: 0.5rem;
+    align-items: start;
+    text-align: start;
+}
+
+.tenant-container {
+    display: flex;
+    flex-direction: column;
+}
+
+.tenant-options-children-container {
+    margin-left: 2rem;
+    margin-top: 0.25rem;
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+    gap: 0.25rem;
+}
+
+.tenant-options-children-container[hidden] {
+    display: none;
+}
+
+.tenant-header {
+    width: 14rem;
+    display: flex;
+    flex-direction: row;
+}
+
+.tenant-filler {
+    flex: 1;
+}
+
+.tenant-count-container {
+    display: flex;
+    flex-direction: row;
+    cursor: pointer;
+}
+
+.tenant-count {
+    width: 1rem;
+    user-select: none;
+    color: var(--secondary-text-color);
+    text-align: center;
+}
+
+.tenant {
+    width: 1rem;
+    height: 1rem;
+    margin-left: 0.5rem;
+    align-self: center;
+}
+
+.tenant > span {
+    display: inline-table;
+    width: 0.5rem;
+    height: 0.5rem;
+    border: solid var(--text-color);
+    border-width: 0 0 0.125rem 0.125rem;
+}
+
+.tenant-expand > span {
+    transform: rotate(-45deg);
+    margin-bottom: 0.5rem;
+}
+
+.tenant-collapse > span {
+    transform: rotate(135deg);
+    margin-top: 0.25rem;
+}
+
+.tenant-option-container {
+    user-select: none;
+    display: flex;
+    flex-direction: row;
+    gap: 0.5rem;
+    cursor: pointer;
+    align-items: center;
+}
+
+.tenant-option-option-input {
+    width: 0;
+    height: 0;
+    opacity: 0;
+}
+
+.tenant-option-checkbox {
+    width: 1rem;
+    height: 1rem;
+    background-color: var(--switch-disabled-bg-color);
+    border: 1px solid var(--button-bg-color);
+    border-radius: 0.125rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+}
+
+.tenant-option-container:hover .tenant-option-checkbox {
+    background-color: var(--switch-disabled-hover-bg-color);
+}
+
+.tenant-option-checkbox-partial {
+    width: 1rem;
+    height: 1rem;
+    background-color: var(--button-bg-color);
+    border: 1px solid var(--button-bg-color);
+    border-radius: 0.125rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+}
+
+.tenant-option-container:hover .tenant-option-checkbox-partial {
+    background-color: var(--button-bg-hover-color);
+}
+
+.tenant-option-checkbox-partial::after {
+    content: '';
+    width: 0.5rem;
+    height: 0;
+    border: solid white;
+    border-width: 0 0 0.125rem 0.125rem;
+    position: absolute;
+}
+
+input:checked + .tenant-option-checkbox {
+    width: 1rem;
+    height: 1rem;
+    background-color: var(--button-bg-color);
+    border: 1px solid var(--button-bg-color);
+    border-radius: 0.125rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+}
+
+.tenant-option-container:hover:has(> input:checked) .tenant-option-checkbox {
+    background-color: var(--button-bg-hover-color);
+}
+
+input:checked + .tenant-option-checkbox::after {
+    content: '';
+    width: 0.5rem;
+    height: 0.25rem;
+    border: solid white;
+    border-width: 0 0 0.125rem 0.125rem;
+    transform: rotate(-45deg);
+    position: absolute;
+    margin-bottom: 0.125rem;
+}

--- a/packages/react-components/src/components/TenantSelection.tsx
+++ b/packages/react-components/src/components/TenantSelection.tsx
@@ -13,6 +13,12 @@ const TenantSelection: FC<{
 
     const selectedTenantCount = selectedTenantIds.size;
 
+    const deletedTenants = Array.from(selectedTenantIds)
+        .filter((selectedTenantId) => !tenants.find(({ id }) => id === selectedTenantId))
+        .map((tenantId) => ({ name: 'Unknown', id: tenantId } as Tenant));
+
+    const allTenants = [...tenants, ...deletedTenants];
+
     return (
         <div className="tenant-container" id="tenant-container">
             <div className="tenant-header">
@@ -23,7 +29,7 @@ const TenantSelection: FC<{
                         checked={isChecked}
                         id="all-tenants"
                         onChange={(e): void => {
-                            tenants.forEach((tenant) => {
+                            allTenants.forEach((tenant) => {
                                 onTenantCheckChange(tenant, e.target.checked);
                             });
                         }}
@@ -38,17 +44,17 @@ const TenantSelection: FC<{
                     All tenants
                 </label>
 
-                <div hidden={tenants.length <= 1} className="tenant-filler" />
+                <div hidden={allTenants.length <= 1} className="tenant-filler" />
 
                 <div
                     className="tenant-count-container"
                     onClick={(): void => setExpanded(!isExpanded)}
                 >
-                    <div hidden={tenants.length <= 1} className="tenant-count">
+                    <div hidden={allTenants.length <= 1} className="tenant-count">
                         {selectedTenantCount}
                     </div>
                     <div
-                        hidden={tenants.length <= 1}
+                        hidden={allTenants.length <= 1}
                         className={`tenant ${isExpanded ? 'tenant-collapse' : 'tenant-expand'}`}
                     >
                         <span />
@@ -56,8 +62,8 @@ const TenantSelection: FC<{
                 </div>
             </div>
             <div className="tenant-options-children-container" hidden={!isExpanded}>
-                {tenants.length > 1 &&
-                    tenants.map((tenant) => {
+                {allTenants.length > 1 &&
+                    allTenants.map((tenant) => {
                         return (
                             <label
                                 className="tenant-option-container"
@@ -74,7 +80,7 @@ const TenantSelection: FC<{
                                     }
                                 />
                                 <div className="tenant-option-checkbox" />
-                                {tenant.name}
+                                {tenant.name} ({tenant.id})
                             </label>
                         );
                     })}

--- a/packages/react-components/src/components/TenantSelection.tsx
+++ b/packages/react-components/src/components/TenantSelection.tsx
@@ -1,0 +1,86 @@
+import React, { FC, useState } from 'react';
+
+import { Tenant } from '../models/flare';
+import './TenantSelection.css';
+
+const TenantSelection: FC<{
+    isChecked?: boolean;
+    tenants: Tenant[];
+    selectedTenantIds: Set<number>;
+    onTenantCheckChange: (tenant: Tenant, isChecked: boolean) => void;
+}> = ({ isChecked = false, tenants, selectedTenantIds, onTenantCheckChange }) => {
+    const [isExpanded, setExpanded] = useState(true);
+
+    const selectedTenantCount = selectedTenantIds.size;
+
+    return (
+        <div className="tenant-container" id="tenant-container">
+            <div className="tenant-header">
+                <label className="tenant-option-container" htmlFor="all-tenants">
+                    <input
+                        className="tenant-option-option-input"
+                        type="checkbox"
+                        checked={isChecked}
+                        id="all-tenants"
+                        onChange={(e): void => {
+                            tenants.forEach((tenant) => {
+                                onTenantCheckChange(tenant, e.target.checked);
+                            });
+                        }}
+                    />
+                    <div
+                        className={
+                            selectedTenantCount > 0 && !isChecked
+                                ? 'tenant-option-checkbox-partial'
+                                : 'tenant-option-checkbox'
+                        }
+                    />
+                    All tenants
+                </label>
+
+                <div hidden={tenants.length <= 1} className="tenant-filler" />
+
+                <div
+                    className="tenant-count-container"
+                    onClick={(): void => setExpanded(!isExpanded)}
+                >
+                    <div hidden={tenants.length <= 1} className="tenant-count">
+                        {selectedTenantCount}
+                    </div>
+                    <div
+                        hidden={tenants.length <= 1}
+                        className={`tenant ${isExpanded ? 'tenant-collapse' : 'tenant-expand'}`}
+                    >
+                        <span />
+                    </div>
+                </div>
+            </div>
+            <div className="tenant-options-children-container" hidden={!isExpanded}>
+                {tenants.length > 1 &&
+                    tenants.map((tenant) => {
+                        return (
+                            <label
+                                className="tenant-option-container"
+                                key={tenant.id}
+                                htmlFor={String(tenant.id)}
+                            >
+                                <input
+                                    className="tenant-option-option-input"
+                                    type="checkbox"
+                                    checked={selectedTenantIds.has(tenant.id)}
+                                    id={String(tenant.id)}
+                                    onChange={(e): void =>
+                                        onTenantCheckChange(tenant, e.target.checked)
+                                    }
+                                />
+                                <div className="tenant-option-checkbox" />
+                                {tenant.name}
+                            </label>
+                        );
+                    })}
+            </div>
+        </div>
+    );
+};
+
+export default TenantSelection;

--- a/packages/react-components/src/models/constants.ts
+++ b/packages/react-components/src/models/constants.ts
@@ -13,6 +13,7 @@ export const SEVERITY_SAVED_SEARCH_NAME = 'Severity';
 export enum PasswordKeys {
     API_KEY = 'api_key',
     TENANT_ID = 'tenant_id',
+    TENANT_IDS = 'tenant_ids',
     INGEST_FULL_EVENT_DATA = 'ingest_full_event_data',
     SEVERITIES_FILTER = 'severities_filter',
     SOURCE_TYPES_FILTER = 'source_types_filter',

--- a/packages/react-components/src/models/constants.ts
+++ b/packages/react-components/src/models/constants.ts
@@ -12,7 +12,6 @@ export const SEVERITY_SAVED_SEARCH_NAME = 'Severity';
 
 export enum PasswordKeys {
     API_KEY = 'api_key',
-    TENANT_ID = 'tenant_id',
     TENANT_IDS = 'tenant_ids',
     INGEST_FULL_EVENT_DATA = 'ingest_full_event_data',
     SEVERITIES_FILTER = 'severities_filter',

--- a/packages/react-components/src/models/flare.ts
+++ b/packages/react-components/src/models/flare.ts
@@ -26,5 +26,4 @@ export interface SourceTypeCategory extends SourceType {
 
 export interface IngestionStatus {
     last_fetched_at: string;
-    last_tenant_id: string;
 }

--- a/packages/react-components/src/utils/setupConfiguration.ts
+++ b/packages/react-components/src/utils/setupConfiguration.ts
@@ -117,7 +117,7 @@ async function savePassword(storage: StoragePasswords, key: string, value: strin
 
 async function saveConfiguration(
     apiKey: string,
-    tenantId: number,
+    tenantIds: number[],
     indexName: string,
     isIngestingFullEventData: boolean,
     severitiesFilter: string,
@@ -126,7 +126,7 @@ async function saveConfiguration(
     const service = createService();
     const storagePasswords = await promisify(service.storagePasswords().fetch)();
     await savePassword(storagePasswords, PasswordKeys.API_KEY, apiKey);
-    await savePassword(storagePasswords, PasswordKeys.TENANT_ID, `${tenantId}`);
+    await savePassword(storagePasswords, PasswordKeys.TENANT_IDS, JSON.stringify(tenantIds));
     await savePassword(
         storagePasswords,
         PasswordKeys.INGEST_FULL_EVENT_DATA,
@@ -239,6 +239,19 @@ async function fetchTenantId(): Promise<number | undefined> {
         }
 
         return undefined;
+    });
+}
+
+async function fetchTenantIds(): Promise<number[]> {
+    return fetchPassword(PasswordKeys.TENANT_IDS).then((tenantIds) => {
+        if (!tenantIds) {
+            return [];
+        }
+        try {
+            return JSON.parse(tenantIds);
+        } catch {
+            return [];
+        }
     });
 }
 
@@ -445,6 +458,7 @@ export {
     fetchSourceTypeFilters,
     fetchSourceTypesFilter,
     fetchTenantId,
+    fetchTenantIds,
     fetchUserTenants,
     fetchVersionName,
     getFlareSearchDataUrl,

--- a/packages/react-components/src/utils/setupConfiguration.ts
+++ b/packages/react-components/src/utils/setupConfiguration.ts
@@ -210,7 +210,6 @@ async function fetchIngestionStatus(): Promise<IngestionStatus> {
     return (
         data || {
             last_fetched_at: '',
-            last_tenant_id: '',
         }
     );
 }
@@ -230,16 +229,6 @@ async function fetchPassword(passwordKey: string): Promise<string | undefined> {
 
 async function fetchApiKey(): Promise<string> {
     return (await fetchPassword(PasswordKeys.API_KEY)) || '';
-}
-
-async function fetchTenantId(): Promise<number | undefined> {
-    return fetchPassword(PasswordKeys.TENANT_ID).then((tenantId) => {
-        if (tenantId) {
-            return parseInt(tenantId, 10);
-        }
-
-        return undefined;
-    });
 }
 
 async function fetchTenantIds(): Promise<number[]> {
@@ -457,7 +446,6 @@ export {
     fetchSeveritiesFilter,
     fetchSourceTypeFilters,
     fetchSourceTypesFilter,
-    fetchTenantId,
     fetchTenantIds,
     fetchUserTenants,
     fetchVersionName,


### PR DESCRIPTION
This PR aims to move from a single tenant install to a multi-tenant install with tenant selection in the configuration screen. It will not be backwards compatible with existing installs, but neither was the branch it was based on.

## Changes 
- Added a tenant selector that supports multiple tenants.
- Added support for multiple tenant cursors and ingestion start dates.
- Modified the cron job to support multiple tenants.
- Added a new password key that supports a list of tenants.

### Configuration interface
<img width="242" alt="Screenshot 2025-03-07 at 1 08 35 PM" src="https://github.com/user-attachments/assets/1c2534c1-edc7-4c3a-a020-0e7d87bdb704" />

### Example data storage
```
[tenant_data]
timestamp_earliest_ingested_123 = 2025-03-07T00:00:00.857510+00:00
next_123 =ABCD
timestamp_earliest_ingested_321 = 2025-02-05T17:38:16.020474+00:00
next_321 =ABASED

[metadata]
timestamp_last_fetch = 2025-03-07T18:06:38.586505+00:00
```