### PR TITLE
Fix mock for flare api

### DIFF
--- a/packages/flare/bin/cron_job_ingest_events.py
+++ b/packages/flare/bin/cron_job_ingest_events.py
@@ -101,7 +101,11 @@ def fetch_feed(
     flare_api_cls: type[FlareAPI],
     data_store: ConfigDataStore,
 ) -> Iterator[tuple[dict, str]]:
-    flare_api: FlareAPI = flare_api_cls(api_key=api_key, tenant_id=tenant_id)
+    flare_api: FlareAPI = flare_api_cls(
+        api_key=api_key,
+        tenant_id=tenant_id,
+        logger=logger,
+    )
 
     try:
         next = data_store.get_next_by_tenant(tenant_id)

--- a/packages/flare/tests/bin/conftest.py
+++ b/packages/flare/tests/bin/conftest.py
@@ -61,7 +61,7 @@ class FakeLogger(Logger):
 
 
 class FakeFlareAPI(FlareAPI):
-    def __init__(self, api_key: str, tenant_id: int) -> None:
+    def __init__(self, api_key: str, tenant_id: int, logger: Logger) -> None:
         pass
 
     def fetch_feed_events(


### PR DESCRIPTION
This was missed when refactoring the tests in a previous PR.

A better solution would be to refactor how the FlareAPI is mocked but that is for another day.