### PR TITLE
Add setting for backfilling events on setup

### DIFF
--- a/packages/flare/bin/constants.py
+++ b/packages/flare/bin/constants.py
@@ -15,6 +15,7 @@ class PasswordKeys(Enum):
     INGEST_FULL_EVENT_DATA = "ingest_full_event_data"
     SEVERITIES_FILTER = "severities_filter"
     SOURCE_TYPES_FILTER = "source_types_filter"
+    NUMBER_OF_DAYS_TO_BACKFILL = "number_of_days_to_backfill"
 
 
 class DataStoreKeys(Enum):

--- a/packages/flare/bin/cron_job_ingest_events.py
+++ b/packages/flare/bin/cron_job_ingest_events.py
@@ -1,5 +1,4 @@
 import json
-from optparse import Option
 import os
 import sys
 
@@ -150,7 +149,7 @@ def get_number_of_days_to_backfill(storage_passwords: client.StoragePasswords) -
 
     try:
         return int(number_of_days_to_backfill) if number_of_days_to_backfill else 30
-    finally:
+    except:
         raise Exception("Number of days to backfill not a number")
 
 

--- a/packages/flare/bin/cron_job_ingest_events.py
+++ b/packages/flare/bin/cron_job_ingest_events.py
@@ -61,8 +61,12 @@ def main(
         # for identifiers 30 days prior to the day a tenant was first configured.
         start_date = data_store.get_earliest_ingested_by_tenant(tenant_id)
         if not start_date:
-            number_of_days_to_backfill = get_number_of_days_to_backfill(storage_passwords=storage_passwords)
-            start_date = datetime.now(timezone.utc) - timedelta(days=number_of_days_to_backfill)
+            number_of_days_to_backfill = get_number_of_days_to_backfill(
+                storage_passwords=storage_passwords
+            )
+            start_date = datetime.now(timezone.utc) - timedelta(
+                days=number_of_days_to_backfill
+            )
             data_store.set_earliest_ingested_by_tenant(tenant_id, start_date)
 
         for event, next_token in fetch_feed(
@@ -142,9 +146,11 @@ def get_api_key(storage_passwords: client.StoragePasswords) -> str:
         raise Exception("API key not found")
     return api_key
 
+
 def get_number_of_days_to_backfill(storage_passwords: client.StoragePasswords) -> int:
     number_of_days_to_backfill = get_storage_password_value(
-        storage_passwords=storage_passwords, password_key=PasswordKeys.NUMBER_OF_DAYS_TO_BACKFILL.value
+        storage_passwords=storage_passwords,
+        password_key=PasswordKeys.NUMBER_OF_DAYS_TO_BACKFILL.value,
     )
 
     try:

--- a/packages/flare/bin/cron_job_ingest_events.py
+++ b/packages/flare/bin/cron_job_ingest_events.py
@@ -1,4 +1,5 @@
 import json
+from optparse import Option
 import os
 import sys
 
@@ -61,7 +62,8 @@ def main(
         # for identifiers 30 days prior to the day a tenant was first configured.
         start_date = data_store.get_earliest_ingested_by_tenant(tenant_id)
         if not start_date:
-            start_date = datetime.now(timezone.utc) - timedelta(days=30)
+            number_of_days_to_backfill = get_number_of_days_to_backfill(storage_passwords=storage_passwords)
+            start_date = datetime.now(timezone.utc) - timedelta(days=number_of_days_to_backfill)
             data_store.set_earliest_ingested_by_tenant(tenant_id, start_date)
 
         for event, next_token in fetch_feed(
@@ -140,6 +142,16 @@ def get_api_key(storage_passwords: client.StoragePasswords) -> str:
     if not api_key:
         raise Exception("API key not found")
     return api_key
+
+def get_number_of_days_to_backfill(storage_passwords: client.StoragePasswords) -> int:
+    number_of_days_to_backfill = get_storage_password_value(
+        storage_passwords=storage_passwords, password_key=PasswordKeys.NUMBER_OF_DAYS_TO_BACKFILL.value
+    )
+
+    try:
+        return int(number_of_days_to_backfill) if number_of_days_to_backfill else 30
+    finally:
+        raise Exception("Number of days to backfill not a number")
 
 
 def get_tenant_ids(storage_passwords: client.StoragePasswords) -> list[int]:

--- a/packages/flare/bin/cron_job_ingest_events.py
+++ b/packages/flare/bin/cron_job_ingest_events.py
@@ -155,8 +155,8 @@ def get_number_of_days_to_backfill(storage_passwords: client.StoragePasswords) -
 
     try:
         return int(number_of_days_to_backfill) if number_of_days_to_backfill else 30
-    except:
-        raise Exception("Number of days to backfill not a number")
+    except Exception as e:
+        raise Exception("Number of days to backfill not a number") from e
 
 
 def get_tenant_ids(storage_passwords: client.StoragePasswords) -> list[int]:

--- a/packages/react-components/src/components/ConfigurationUserPreferencesStep.tsx
+++ b/packages/react-components/src/components/ConfigurationUserPreferencesStep.tsx
@@ -26,6 +26,7 @@ import {
     saveConfiguration,
     convertSourceTypeFilterToArray,
     fetchTenantIds,
+    fetchNumberOfDaysToBackfill,
 } from '../utils/setupConfiguration';
 import './ConfigurationGlobalStep.css';
 import './ConfigurationUserPreferencesStep.css';
@@ -36,6 +37,7 @@ import { ToastKeys, toastManager } from './ToastManager';
 import Tooltip from './Tooltip';
 import FlareLogoLoading from './FlareLogoLoading';
 import TenantSelection from './TenantSelection';
+import Input from './Input';
 
 const ConfigurationUserPreferencesStep: FC<{
     configurationStep: ConfigurationStep;
@@ -54,6 +56,8 @@ const ConfigurationUserPreferencesStep: FC<{
     const [indexNames, setIndexNames] = useState<string[]>([]);
     const [isIngestingFullEventData, setIsIngestingFullEventData] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
+    const [numberOfDaysToBackfill, setNumberOfDaysToBackfill] = useState<string>();
+    const [isFirstSetup, setIsFirstSetup] = useState(false);
 
     const handleIndexNameChange = (e): void => setIndexName(e.target.value);
     const handleIsIngestingFullEventDataChange = (e): void =>
@@ -68,7 +72,8 @@ const ConfigurationUserPreferencesStep: FC<{
             indexName,
             isIngestingFullEventData,
             getSeverityFilterValue(selectedSeverities, severities),
-            getSourceTypesFilterValue(selectedSourceTypes, sourceTypeCategories)
+            getSourceTypesFilterValue(selectedSourceTypes, sourceTypeCategories),
+            numberOfDaysToBackfill
         )
             .then(() => {
                 setIsLoading(false);
@@ -101,6 +106,7 @@ const ConfigurationUserPreferencesStep: FC<{
                 fetchSeveritiesFilter(),
                 fetchSourceTypeFilters(apiKey),
                 fetchSourceTypesFilter(),
+                fetchNumberOfDaysToBackfill(),
             ])
                 .then(
                     ([
@@ -113,7 +119,14 @@ const ConfigurationUserPreferencesStep: FC<{
                         severitiesFilter,
                         allSourceTypeCategories,
                         sourceTypeFilter,
+                        numberOfDaysToBackfillSaved,
                     ]) => {
+                        // The form can't be submitted without any tenant ids
+                        // so the absence of tenant ids indicates that it is the first setup.
+                        if (!tenantIds) {
+                            setIsFirstSetup(true);
+                        }
+                        setNumberOfDaysToBackfill(numberOfDaysToBackfillSaved ?? '');
                         setSelectedTenantIds(new Set(tenantIds));
                         setIsIngestingFullEventData(ingestFullEventData);
                         setIndexName(index);
@@ -264,6 +277,25 @@ const ConfigurationUserPreferencesStep: FC<{
                             onChange={handleIsIngestingFullEventDataChange}
                         />
                     </span>
+                </div>
+                <div className="form-item">
+                    <div className="label-tooltip">
+                        <Label>Number of days to backfill events</Label>
+                        <Tooltip>
+                            <div>
+                                This field can only be set when setting up the app for the first
+                                time.
+                            </div>
+                        </Tooltip>
+                    </div>
+                    <Input
+                        onChange={(e): void => setNumberOfDaysToBackfill(e.target.value)}
+                        value={numberOfDaysToBackfill}
+                        min="0"
+                        type="number"
+                        placeholder="30"
+                        disabled={!isFirstSetup}
+                    />
                 </div>
                 <div className="button-group">
                     <Button onClick={(): void => onNavigateBackClick()} isSecondary>

--- a/packages/react-components/src/components/ConfigurationUserPreferencesStep.tsx
+++ b/packages/react-components/src/components/ConfigurationUserPreferencesStep.tsx
@@ -123,7 +123,7 @@ const ConfigurationUserPreferencesStep: FC<{
                     ]) => {
                         // The form can't be submitted without any tenant ids
                         // so the absence of tenant ids indicates that it is the first setup.
-                        if (!tenantIds) {
+                        if (!tenantIds.length) {
                             setIsFirstSetup(true);
                         }
                         setNumberOfDaysToBackfill(numberOfDaysToBackfillSaved ?? '');

--- a/packages/react-components/src/components/Input.css
+++ b/packages/react-components/src/components/Input.css
@@ -1,0 +1,5 @@
+input {
+    color: var(--text-color);
+    border: 0px;
+    outline: none;
+}

--- a/packages/react-components/src/components/Input.tsx
+++ b/packages/react-components/src/components/Input.tsx
@@ -1,0 +1,9 @@
+import React, { FC } from 'react';
+
+import './Input.css';
+
+const Input: FC<React.ComponentProps<'input'>> = ({ ...props }) => {
+    return <input {...props} />;
+};
+
+export default Input;

--- a/packages/react-components/src/global.css
+++ b/packages/react-components/src/global.css
@@ -77,10 +77,17 @@ input {
     border: 1px solid var(--secondary-text-color);
     border-radius: 40px;
     margin-top: 0.5rem;
+
+    &:disabled {
+        cursor: not-allowed;
+        color: var(--secondary-text-color);
+    }
 }
 
 input:hover {
-    border: 1px solid var(--button-bg-color);
+    :not(:disabled){
+        border: 1px solid var(--button-bg-color);
+    }
 }
 
 input::placeholder {

--- a/packages/react-components/src/global.css
+++ b/packages/react-components/src/global.css
@@ -85,7 +85,7 @@ input {
 }
 
 input:hover {
-    :not(:disabled){
+    :not(:disabled) {
         border: 1px solid var(--button-bg-color);
     }
 }

--- a/packages/react-components/src/models/constants.ts
+++ b/packages/react-components/src/models/constants.ts
@@ -16,4 +16,5 @@ export enum PasswordKeys {
     INGEST_FULL_EVENT_DATA = 'ingest_full_event_data',
     SEVERITIES_FILTER = 'severities_filter',
     SOURCE_TYPES_FILTER = 'source_types_filter',
+    NUMBER_OF_DAYS_TO_BACKFILL = "number_of_days_to_backfill"
 }

--- a/packages/react-components/src/models/constants.ts
+++ b/packages/react-components/src/models/constants.ts
@@ -16,5 +16,5 @@ export enum PasswordKeys {
     INGEST_FULL_EVENT_DATA = 'ingest_full_event_data',
     SEVERITIES_FILTER = 'severities_filter',
     SOURCE_TYPES_FILTER = 'source_types_filter',
-    NUMBER_OF_DAYS_TO_BACKFILL = "number_of_days_to_backfill"
+    NUMBER_OF_DAYS_TO_BACKFILL = 'number_of_days_to_backfill',
 }

--- a/packages/react-components/src/utils/setupConfiguration.ts
+++ b/packages/react-components/src/utils/setupConfiguration.ts
@@ -133,7 +133,6 @@ async function saveConfiguration(
         PasswordKeys.INGEST_FULL_EVENT_DATA,
         `${isIngestingFullEventData}`
     );
-    debugger
     await savePassword(storagePasswords, PasswordKeys.NUMBER_OF_DAYS_TO_BACKFILL, numberOfDaysToBackfill ?? '');
     await savePassword(storagePasswords, PasswordKeys.SEVERITIES_FILTER, `${severitiesFilter}`);
     await savePassword(storagePasswords, PasswordKeys.SOURCE_TYPES_FILTER, `${sourceTypesFilter}`);

--- a/packages/react-components/src/utils/setupConfiguration.ts
+++ b/packages/react-components/src/utils/setupConfiguration.ts
@@ -121,7 +121,8 @@ async function saveConfiguration(
     indexName: string,
     isIngestingFullEventData: boolean,
     severitiesFilter: string,
-    sourceTypesFilter: string
+    sourceTypesFilter: string,
+    numberOfDaysToBackfill?: string,
 ): Promise<void> {
     const service = createService();
     const storagePasswords = await promisify(service.storagePasswords().fetch)();
@@ -132,6 +133,8 @@ async function saveConfiguration(
         PasswordKeys.INGEST_FULL_EVENT_DATA,
         `${isIngestingFullEventData}`
     );
+    debugger
+    await savePassword(storagePasswords, PasswordKeys.NUMBER_OF_DAYS_TO_BACKFILL, numberOfDaysToBackfill ?? '');
     await savePassword(storagePasswords, PasswordKeys.SEVERITIES_FILTER, `${severitiesFilter}`);
     await savePassword(storagePasswords, PasswordKeys.SOURCE_TYPES_FILTER, `${sourceTypesFilter}`);
     await saveIndexForIngestion(service, indexName);
@@ -219,6 +222,8 @@ async function fetchPassword(passwordKey: string): Promise<string | undefined> {
     const storagePasswords = await promisify(service.storagePasswords().fetch)();
     const passwordId = `${STORAGE_REALM}:${passwordKey}:`;
 
+    console.log(storagePasswords.list())
+
     for (const password of storagePasswords.list()) {
         if (password.name === passwordId) {
             return password.properties().clear_password;
@@ -241,6 +246,12 @@ async function fetchTenantIds(): Promise<number[]> {
         } catch {
             return [];
         }
+    });
+}
+
+async function fetchNumberOfDaysToBackfill(): Promise<string | undefined> {
+    return fetchPassword(PasswordKeys.NUMBER_OF_DAYS_TO_BACKFILL).then((numberOfDaysToBackfill) => {
+        return numberOfDaysToBackfill
     });
 }
 
@@ -446,6 +457,7 @@ export {
     fetchSeveritiesFilter,
     fetchSourceTypeFilters,
     fetchSourceTypesFilter,
+    fetchNumberOfDaysToBackfill,
     fetchTenantIds,
     fetchUserTenants,
     fetchVersionName,

--- a/packages/react-components/src/utils/setupConfiguration.ts
+++ b/packages/react-components/src/utils/setupConfiguration.ts
@@ -122,7 +122,7 @@ async function saveConfiguration(
     isIngestingFullEventData: boolean,
     severitiesFilter: string,
     sourceTypesFilter: string,
-    numberOfDaysToBackfill?: string,
+    numberOfDaysToBackfill?: string
 ): Promise<void> {
     const service = createService();
     const storagePasswords = await promisify(service.storagePasswords().fetch)();
@@ -133,7 +133,11 @@ async function saveConfiguration(
         PasswordKeys.INGEST_FULL_EVENT_DATA,
         `${isIngestingFullEventData}`
     );
-    await savePassword(storagePasswords, PasswordKeys.NUMBER_OF_DAYS_TO_BACKFILL, numberOfDaysToBackfill ?? '');
+    await savePassword(
+        storagePasswords,
+        PasswordKeys.NUMBER_OF_DAYS_TO_BACKFILL,
+        numberOfDaysToBackfill ?? ''
+    );
     await savePassword(storagePasswords, PasswordKeys.SEVERITIES_FILTER, `${severitiesFilter}`);
     await savePassword(storagePasswords, PasswordKeys.SOURCE_TYPES_FILTER, `${sourceTypesFilter}`);
     await saveIndexForIngestion(service, indexName);
@@ -221,8 +225,6 @@ async function fetchPassword(passwordKey: string): Promise<string | undefined> {
     const storagePasswords = await promisify(service.storagePasswords().fetch)();
     const passwordId = `${STORAGE_REALM}:${passwordKey}:`;
 
-    console.log(storagePasswords.list())
-
     for (const password of storagePasswords.list()) {
         if (password.name === passwordId) {
             return password.properties().clear_password;
@@ -250,7 +252,7 @@ async function fetchTenantIds(): Promise<number[]> {
 
 async function fetchNumberOfDaysToBackfill(): Promise<string | undefined> {
     return fetchPassword(PasswordKeys.NUMBER_OF_DAYS_TO_BACKFILL).then((numberOfDaysToBackfill) => {
-        return numberOfDaysToBackfill
+        return numberOfDaysToBackfill;
     });
 }
 


### PR DESCRIPTION
Adds the ability to configure how far in the past we backfill events, without refactoring the fetching logic this will only be configurable the first time the configuration agent is run.

#### With value
<img width="376" alt="Screenshot 2025-03-17 at 9 10 44 PM" src="https://github.com/user-attachments/assets/6bb42a56-f302-4e49-8750-21a801b3120a" />

#### Default value
<img width="376" alt="Screenshot 2025-03-17 at 9 09 05 PM" src="https://github.com/user-attachments/assets/0a2d7207-d05a-408c-9503-825d1c165b0e" />
