### PR TITLE
feature: added 8088 to the exposed port in compose.yaml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,7 @@ services:
     restart: unless-stopped
     ports:
       - "8000:8000"
+      - "8088:8088"
     environment:
       - SPLUNK_START_ARGS=--accept-license
       - SPLUNK_PASSWORD=a_password


### PR DESCRIPTION
# Summary

Minor change to expose the API port in the `docker-compose.yaml` file. I needed this change to test Splunk API endpoints.