### PR TITLE
Update splunk version while fixing CI issues

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,6 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+            python-version: '3.9'
+
       - name: Download Build Artifact
         uses: actions/download-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ venv: requirements.txt
 	@rm -rf packages/flare/bin/vendor/bin
 	@rm -rf packages/flare/bin/vendor/packaging
 	@rm -rf packages/flare/bin/vendor/*-stubs
-	@rm -rf packages/flare/bin/vendor/charset_normalizer/md.cpython-39-x86_64-linux-gnu.so
-	@rm -rf packages/flare/bin/vendor/charset_normalizer/md__mypyc.cpython-39-x86_64-linux-gnu.so
+	@find packages/flare/bin/vendor -type f -name "*x86_64-linux-gnu.so" -delete
 
 venv-tools: requirements.tools.txt venv
 	rm -rf venv-tools

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,9 @@ publish: output/flare.tar.gz
 validate: venv-tools
 	@echo "Running Splunk AppInspect..."
 	@echo "If you get an error about \"libmagic\", run \"brew install libmagic\""
-	@venv-tools/bin/splunk-appinspect inspect --ci "output/flare" || \
-	if test  "$$?" -eq "102" || "$$?" -eq "103" ; then \
+	@venv-tools/bin/splunk-appinspect inspect --ci "output/flare" ; \
+	status=$$? ; \
+	if [ "$$status" -eq 0 ] || [ "$$status" -eq 102 ] || [ "$$status" -eq 103 ] ; then \
 		exit 0 ; \
 	else \
 		exit 1 ; \

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,8 @@
 # Flare
+1.3.4
+-----
+* Update the minimum version of the Flare SDK. 
+
 1.3.3
 -----
 * Bump the version number and to update the splunkbase listing to support Splunk v10. 

--- a/packages/flare/src/main/resources/splunk/default/app.conf
+++ b/packages/flare/src/main/resources/splunk/default/app.conf
@@ -13,7 +13,7 @@ id = flare
 python.version = python3.9
 state_change_requires_restart = true
 is_configured = 0
-build = 10
+build = 11
 
 [ui]
 is_visible = 1
@@ -24,7 +24,7 @@ supported_themes = light, dark
 [launcher]
 author = Flare Systems
 description = The Flare app allows you to integrate your Flare alerts with the Splunk platform.
-version = 1.3.3
+version = 1.3.4
 
 [triggers]
 reload.splunk_create = simple

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests==2.30.0
 splunk-sdk==2.0.2
 types-requests==2.30.0.0
 urllib3==1.26.15
-flareio>=0.1.25
+flareio>=2.4.1


### PR DESCRIPTION
Raising the flareio version so that we use the latest version with tested python 3.9 compatibility.